### PR TITLE
fix: Use npm template package

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,9 +7,9 @@ const spawn = require('cross-spawn');
 const path = require('path');
 const tildify = require('tildify');
 const Spinner = require('cli-spinner').Spinner;
+const readline = require('readline');
 const promptAppDefinitionSettings = require('./prompt-app-definition');
 const createAppDefinition = require('./create-app-definition');
-const readline = require('readline');
 const stream = process.stdout;
 
 const command = process.argv[2];
@@ -58,17 +58,11 @@ function initProject() {
 
     spinner.setSpinnerString('⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏');
 
-    const initCommand = 'npx';
-    const execPath = path.resolve(__dirname, '../');
+    const initCommand = 'node';
+    const createReactApp = require.resolve('create-react-app');
+    const templatePkg = '@contentful/cra-template-create-contentful-app';
 
-    const args = [
-      'create-react-app',
-      appFolder,
-      '--template',
-      `file:${execPath}`,
-      '--silent',
-      '--use-npm'
-    ];
+    const args = [createReactApp, appFolder, '--template', templatePkg, '--silent', '--use-npm'];
 
     // start creating app
     const appCreateProcess = spawn(initCommand, args, {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/create-contentful-app",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/create-contentful-app",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A template for building Contentful Apps",
   "author": "Contentful GmbH",
   "license": "MIT",


### PR DESCRIPTION
As opposed to using a local one with [`file:` option](https://create-react-app.dev/docs/custom-templates/#testing-a-template)

### Further Details:

https://github.com/facebook/create-react-app/blob/v3.4.1/packages/create-react-app/createReactApp.js#L750 is the problem. It would parse `@contentful` in our name and break. It's partially also a bug on create-react-app. If a template name has `@` in it's name, it will break. Unless it's part of the organization name.

We already published a template on npm: https://www.npmjs.com/package/@contentful/cra-template-create-contentful-app. 

FYI, this means going forward we will publish 3 times: once for template, for org scoped pkg and create-contentful-app parked name.

