### PR TITLE
feat: add current state examples

### DIFF
--- a/template.json
+++ b/template.json
@@ -13,7 +13,7 @@
       "@types/node": "^12.0.0",
       "@types/react": "^16.9.0",
       "@types/react-dom": "^16.9.0",
-      "contentful-ui-extensions-sdk": "3.15.0",
+      "contentful-ui-extensions-sdk": "3.18.0",
       "typescript": "^3.8.0"
     }
   }

--- a/template/src/components/ConfigScreen.spec.tsx
+++ b/template/src/components/ConfigScreen.spec.tsx
@@ -9,7 +9,8 @@ describe('Config Screen component', () => {
       app: {
         onConfigure: jest.fn(),
         getParameters: jest.fn().mockReturnValueOnce({}),
-        setReady: jest.fn()
+        setReady: jest.fn(),
+        getCurrentState: jest.fn()
       }
     };
     const { getByText } = render(<ConfigScreen sdk={mockSdk} />);

--- a/template/src/components/ConfigScreen.tsx
+++ b/template/src/components/ConfigScreen.tsx
@@ -41,9 +41,16 @@ export default class Config extends Component<ConfigProps, ConfigState> {
     // or "Save" in the configuration screen.
     // for more details see https://www.contentful.com/developers/docs/extensibility/ui-extensions/sdk-reference/#register-an-app-configuration-hook
 
+    // Get current the state of EditorInterface and other entities
+    // related to this app installation
+    const currentState = await this.props.sdk.app.getCurrentState();
+
     return {
       // Parameters to be persisted as the app configuration.
-      parameters: this.state.parameters
+      parameters: this.state.parameters,
+      // In case you don't want to submit any update to app
+      // locations, you can just pass the currentState as is
+      targetState: currentState
     };
   };
 


### PR DESCRIPTION
This change is meant to introduce a small example of how `getCurrentState` can be leveraged in `ConfigScreen`.

The main idea here is: there is a way (in v3.18.0) to get a blueprint of the `targetState` which _needs_ to be submitted, unless you want the whole configuration to be reset, and this explains how.