### PR TITLE
chore: add simple deploy script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/create-contentful-app",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/create-contentful-app",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A template for building Contentful Apps",
   "author": "Contentful GmbH",
   "license": "MIT",
@@ -48,7 +48,8 @@
   "scripts": {
     "commit": "git-cz",
     "prettier": "prettier **/*.{js,jsx,ts,tsx} scripts/**/*.js --write --ignore-path .gitignore",
-    "commitmsg": "validate-commit-msg"
+    "commitmsg": "validate-commit-msg",
+    "publish-all": "node scripts/deploy.js"
   },
   "dependencies": {
     "chalk": "^4.1.0",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,32 @@
+#! /usr/bin/env node
+
+const fs = require('fs')
+const childProcess = require('child_process')
+
+const PACKAGES = ['@contentful/create-contentful-app', 'create-contentful-app', '@contentful/cra-template-create-contentful-app']
+const ORIGINAL_PACKAGE_JSON = require('../package.json')
+
+if (!process.env.NPM_TOKEN) {
+  throw new Error('Missing NPM_TOKEN!')
+}
+
+for (const package of PACKAGES) {
+  console.log('')
+  console.log('📦 Deploying package:', package)
+  const packageJson = {...ORIGINAL_PACKAGE_JSON, name: package}
+
+  console.log(` > 📝 Updating package.json with name: ${package}...`)
+  fs.writeFileSync('../package.json', JSON.stringify(packageJson))
+
+  console.log(` > ⚙️  Updating package-lock.json by means of "npm i"...`)
+  childProcess.execSync('npm i', {cwd: '../'})
+
+  console.log(` > 📚 Publishing on the registry...`)
+  childProcess.execSync('npm publish', {cwd: '../'})
+
+  console.log(`✅ Successfully published ${package}@${ORIGINAL_PACKAGE_JSON.version}!`)
+  console.log('')
+}
+
+// Restore original package.json
+fs.writeFileSync('../package.json', JSON.stringify(ORIGINAL_PACKAGE_JSON, null, 2))

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -42,16 +42,18 @@ try {
     spawn.sync('npm', ['i'], { silent: true, cwd: MODULE_MAIN_PATH });
 
     console.log(` > 📚 Publishing ${package} on the registry...`);
-    let { error } = spawn.sync('npm', ['publish', '--access', 'public'], {
+    const { status } = spawn.sync('npm', ['publish', '--access', 'public'], {
       stdio: 'inherit',
       cwd: MODULE_MAIN_PATH
     });
-    if (error) {
-      throw new Error(error);
+    if (status !== 0) {
+      throw new Error(
+        'Failed to publish. Please check the output above and make sure you have the correct credentials, working network and npm is not down.'
+      );
     }
 
     console.log(`✅ Successfully published ${package}@${ORIGINAL_PACKAGE_JSON.version}!`);
-    console.log();
+    console.log('');
   }
 } catch (err) {
   restoreFiles();

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,3 +1,13 @@
+/*
+
+ Needs to be deployed 3 times because we need:
+  - Main  CLI tool (@contentful/create-contentful-app)
+  - Parked named to avoid package squatting (create-contentful-app)
+  - Actual custom template package in accordance to create-react-app
+    - i.e: https://create-react-app.dev/docs/custom-templates/
+
+*/
+
 const fs = require('fs');
 const spawn = require('cross-spawn');
 

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,32 +1,53 @@
-#! /usr/bin/env node
+const fs = require('fs');
+const spawn = require('cross-spawn');
 
-const fs = require('fs')
-const childProcess = require('child_process')
+const PACKAGES = [
+  '@contentful/create-contentful-app',
+  'create-contentful-app',
+  '@contentful/cra-template-create-contentful-app'
+];
+const MODULE_MAIN_PATH = `${__dirname}/../`;
+const ORIGINAL_PACKAGE_JSON = require(`${MODULE_MAIN_PATH}/package.json`);
 
-const PACKAGES = ['@contentful/create-contentful-app', 'create-contentful-app', '@contentful/cra-template-create-contentful-app']
-const ORIGINAL_PACKAGE_JSON = require('../package.json')
+function restoreFiles() {
+  fs.writeFileSync(
+    `${MODULE_MAIN_PATH}/package.json`,
+    JSON.stringify(ORIGINAL_PACKAGE_JSON, null, 2)
+  );
+  spawn.sync('npm', ['i'], { silent: true, cwd: MODULE_MAIN_PATH });
+}
 
 if (!process.env.NPM_TOKEN) {
-  throw new Error('Missing NPM_TOKEN!')
+  throw new Error('Missing NPM_TOKEN!');
 }
 
-for (const package of PACKAGES) {
-  console.log('')
-  console.log('📦 Deploying package:', package)
-  const packageJson = {...ORIGINAL_PACKAGE_JSON, name: package}
+try {
+  for (const package of PACKAGES) {
+    console.log('');
+    console.log('📦 Deploying package:', package);
+    const packageJson = { ...ORIGINAL_PACKAGE_JSON, name: package };
 
-  console.log(` > 📝 Updating package.json with name: ${package}...`)
-  fs.writeFileSync('../package.json', JSON.stringify(packageJson))
+    console.log(` > 📝 Updating package.json with name: ${package}...`);
+    fs.writeFileSync(`${MODULE_MAIN_PATH}/package.json`, JSON.stringify(packageJson));
 
-  console.log(` > ⚙️  Updating package-lock.json by means of "npm i"...`)
-  childProcess.execSync('npm i', {cwd: '../'})
+    console.log(` > ⚙️  Updating package-lock.json by means of "npm i"...`);
+    spawn.sync('npm', ['i'], { silent: true, cwd: MODULE_MAIN_PATH });
 
-  console.log(` > 📚 Publishing on the registry...`)
-  childProcess.execSync('npm publish', {cwd: '../'})
+    console.log(` > 📚 Publishing ${package} on the registry...`);
+    let { error } = spawn.sync('npm', ['publish', '--access', 'public'], {
+      stdio: 'inherit',
+      cwd: MODULE_MAIN_PATH
+    });
+    if (error) {
+      throw new Error(error);
+    }
 
-  console.log(`✅ Successfully published ${package}@${ORIGINAL_PACKAGE_JSON.version}!`)
-  console.log('')
+    console.log(`✅ Successfully published ${package}@${ORIGINAL_PACKAGE_JSON.version}!`);
+    console.log();
+  }
+} catch (err) {
+  restoreFiles();
+  throw new Error(err);
 }
 
-// Restore original package.json
-fs.writeFileSync('../package.json', JSON.stringify(ORIGINAL_PACKAGE_JSON, null, 2))
+restoreFiles();

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,12 +1,10 @@
-/*
+#! /usr/bin/env node
 
- Needs to be deployed 3 times because we need:
-  - Main  CLI tool (@contentful/create-contentful-app)
-  - Parked named to avoid package squatting (create-contentful-app)
-  - Actual custom template package in accordance to create-react-app
-    - i.e: https://create-react-app.dev/docs/custom-templates/
-
-*/
+// Needs to be deployed 3 times because we need:
+//  - Main  CLI tool (@contentful/create-contentful-app)
+//  - Parked named to avoid package squatting (create-contentful-app)
+//  - Actual custom template package in accordance to create-react-app
+//    - i.e: https://create-react-app.dev/docs/custom-templates/
 
 const fs = require('fs');
 const spawn = require('cross-spawn');


### PR DESCRIPTION
## Context

This script is meant to automate the current madness we go through to deploy this package. 

Nothing particularly fancy, and probably this cannot be merged before we produce documentation for these steps, but I have just used it for last release and seems to be working. We can get back to it whenever we are rolling out next release