### PR TITLE
chore: [EXT-2124] automate dependecy check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - run:
           name: Check Outdated
           working_directory: ./dependency-check
-          command: (npm outdated --json || true ) > ./outdated.json
+          command: (npm outdated --json || true) > ./outdated.json
       - run:
           name: Create new template
           command: node ./scripts/dependency-check/create-template-from-outdated
@@ -35,7 +35,7 @@ jobs:
             cd "${TMPDIR}/${PROJECT}"
             npx @contentful/create-contentful-app init test
             cd test
-            ( npm t -- --ci --silent || true ) > "${FORMER_CWD}/dependency-check/test-report"
+            (CI=true npm t || true) 1>"${FORMER_CWD}/dependency-check/test-report" 2>&1
       - run:
           name: Create Pull Request
           command: npm install @octokit/rest@18 simple-git@2 && node ./scripts/dependency-check/create-pull-request

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,16 @@ jobs:
           name: Create new template
           command: node ./scripts/dependency-check/create-template-from-outdated
       - run:
+          name: Run Tests and Produce Reports
+          command: |
+            FORMER_CWD=$(pwd)
+            PROJECT=test-$(date +%s)
+            mkdir "${TMPDIR}/${PROJECT}"
+            cd "${TMPDIR}/${PROJECT}"
+            npx @contentful/create-contentful-app init test
+            cd test
+            npm t > "${FORMER_CWD}/dependency-check/test-report"
+      - run:
           name: Create Pull Request
           command: npm install @octokit/rest simple-git && node ./scripts/dependency-check/create-pull-request
       - run:
@@ -35,14 +45,14 @@ jobs:
 
 workflows:
   version: 2
-  
+
   scheduled-dependency-check:
     triggers:
       - schedule:
-          # Run each day at midnight
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only: master
+        # Run each day at midnight
+        cron: "0 0 * * *"
+        filters:
+          branches:
+            only: master
     jobs:
       - dependency-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
             ( npm t -- --ci --silent || true ) > "${FORMER_CWD}/dependency-check/test-report"
       - run:
           name: Create Pull Request
-          command: npm install @octokit/rest simple-git && node ./scripts/dependency-check/create-pull-request
+          command: npm install @octokit/rest@18 simple-git@2 && node ./scripts/dependency-check/create-pull-request
       - run:
           name: Cleanup
           command: rm -rf ./dependency-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             cd "${TMPDIR}/${PROJECT}"
             npx @contentful/create-contentful-app init test
             cd test
-            npm t > "${FORMER_CWD}/dependency-check/test-report"
+            ( npm t -- --ci --silent || true ) > "${FORMER_CWD}/dependency-check/test-report"
       - run:
           name: Create Pull Request
           command: npm install @octokit/rest simple-git && node ./scripts/dependency-check/create-pull-request
@@ -49,10 +49,10 @@ workflows:
   scheduled-dependency-check:
     triggers:
       - schedule:
-        # Run each day at midnight
-        cron: "0 0 * * *"
-        filters:
-          branches:
-            only: master
+          # Run each day at midnight
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only: master
     jobs:
       - dependency-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,48 @@
+version: 2.1
+
+executors:
+  node-container:
+    docker:
+      - image: node:12
+        environment:
+          NPM_CONFIG_PROGRESS: 'false'
+          NPM_CONFIG_LOGLEVEL: warn
+
+jobs:
+  dependency-check:
+    executor: node-container
+    steps:
+      - checkout
+      - run:
+          name: Create Dependency Check sandbox
+          command: mkdir -p ./dependency-check
+      - run:
+          name: Create Package JSON
+          command: node ./scripts/dependency-check/create-manifest-from-template
+      - run:
+          name: Check Outdated
+          working_directory: ./dependency-check
+          command: (npm outdated --json || true ) > ./outdated.json
+      - run:
+          name: Create new template
+          command: node ./scripts/dependency-check/create-template-from-outdated
+      - run:
+          name: Create Pull Request
+          command: npm install @octokit/rest simple-git && node ./scripts/dependency-check/create-pull-request
+      - run:
+          name: Cleanup
+          command: rm -rf ./dependency-check
+
+workflows:
+  version: 2
+  
+  scheduled-dependency-check:
+    triggers:
+      - schedule:
+          # Run each day at midnight
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only: master
+    jobs:
+      - dependency-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       - run:
           name: Run Tests and Produce Reports
           command: |
-            FORMER_CWD=$(pwd)
+            FORMER_CWD="$(pwd)"
             PROJECT=test-$(date +%s)
             mkdir "${TMPDIR}/${PROJECT}"
             cd "${TMPDIR}/${PROJECT}"

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ yarn-error.log*
 lerna-debug.log*
 
 dist
+/dependency-check
 
 # editors
 .idea

--- a/scripts/dependency-check/create-manifest-from-template
+++ b/scripts/dependency-check/create-manifest-from-template
@@ -1,0 +1,31 @@
+#! /usr/bin/env node
+
+const path = require('path')
+const fs = require('fs');
+const { printErrorAndExit, printInfo, SANDBOX_PATH, TEMPLATE_PATH, printHeader, printSuccess, validateAndRequire } = require('./utils');
+
+const manifestPath = path.join(SANDBOX_PATH, 'package.json');
+
+printHeader(`Creating manifest at ${manifestPath}`);
+
+if (!fs.existsSync(SANDBOX_PATH)) {
+  printErrorAndExit(`Unable to find sandbox environment at ${SANDBOX_PATH}`);
+}
+
+const template = validateAndRequire(TEMPLATE_PATH);
+
+// Create in memory manifest
+const manifest = {
+  name: "test",
+  version: "0.0.1",
+  private: true,
+  dependencies: template.package.dependencies
+}
+
+try {
+  printInfo(`Writing manifest...`)
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2))
+  printSuccess('Successfully created manifest')
+} catch (e) {
+  printErrorAndExit(`Unable to write ${manifestPath}`, e);
+}

--- a/scripts/dependency-check/create-pull-request
+++ b/scripts/dependency-check/create-pull-request
@@ -2,7 +2,36 @@
 
 const { Octokit } = require('@octokit/rest');
 const simpleGit = require('simple-git');
-const { printErrorAndExit, ROOT_PATH, printSuccess, TEMPLATE_PATH } = require('./utils');
+
+const { printErrorAndExit, ROOT_PATH, printSuccess, TEMPLATE_PATH, TEST_REPORT_PATH } = require('./utils');
+
+const getCompatibilityBadge = (report) => {
+  const testLine = report.split('\n').find(i => i.startsWith('Tests:'))
+
+  const [_, passed, total] = /(\d) passed, (\d) total/.exec(testLine);
+  const compatibilityScore = (Number.parseInt(passed) * 100) / Number.parseInt(total);
+
+  const compatibilityColor = compatibilityScore === 100
+    ? 'green'
+    : compatibilityScore > 80
+      ? 'yellow'
+      : 'red'
+
+  return `https://img.shields.io/badge/compatibility-${compatibilityScore}%25-${compatibilityColor}`
+}
+
+const createPullRequestMessage = (report) => `
+Bumps dependencies in \`template.json\` with most up to date versions as of today.
+
+![compatibility score](${getCompatibilityBadge(report)})
+
+<details>
+<summary>Test Report</summary>
+<pre>
+${report}
+</pre>
+</details>
+`
 
 const githubClient = new Octokit({
   auth: process.env.GITHUB_ACCESS_TOKEN
@@ -28,12 +57,11 @@ const gitClient = simpleGit(ROOT_PATH);
 
   await gitClient.add([TEMPLATE_PATH])
 
-  // TODO: 
-  //   if we decide to do this one dependency at time, 
-  //   this should include dependency name and version
   await gitClient.commit('chore(deps): update dependencies')
 
   await gitClient.push(['-u', 'origin', branch])
+
+  const testReport = validateAndRead(TEST_REPORT_PATH)
 
   await githubClient.pulls.create({
     owner: 'contentful',
@@ -41,13 +69,7 @@ const gitClient = simpleGit(ROOT_PATH);
     title: `chore(deps): daily update 'template.json'`,
     head: branch,
     base: 'master',
-    // TODO: 
-    //   if we decide to do this one dependency at time, 
-    //   this should include dependency name and version
-    //   and possibly the changelog too
-    body: `
-      Bumps dependencies in \`template.json\` with latest packages as of today.
-    `
+    body: createPullRequestMessage(testReport)
   });
 })().catch(e => {
   printErrorAndExit('Unable to create a pull request', e);

--- a/scripts/dependency-check/create-pull-request
+++ b/scripts/dependency-check/create-pull-request
@@ -3,10 +3,17 @@
 const { Octokit } = require('@octokit/rest');
 const simpleGit = require('simple-git');
 
-const { printErrorAndExit, ROOT_PATH, printSuccess, TEMPLATE_PATH, TEST_REPORT_PATH } = require('./utils');
+const {
+  TEMPLATE_PATH,
+  TEST_REPORT_PATH,
+  ROOT_PATH,
+  printErrorAndExit,
+  printSuccess,
+  validateAndRead
+} = require('./utils');
 
 const getCompatibilityBadge = (report) => {
-  const testLine = report.split('\n').find(i => i.startsWith('Tests:'))
+  const testLine = report.split('\n').find(i => i.startsWith('Tests:'));
 
   const [_, passed, total] = /(\d) passed, (\d) total/.exec(testLine);
   const compatibilityScore = (Number.parseInt(passed) * 100) / Number.parseInt(total);
@@ -15,10 +22,10 @@ const getCompatibilityBadge = (report) => {
     ? 'green'
     : compatibilityScore > 80
       ? 'yellow'
-      : 'red'
+      : 'red';
 
-  return `https://img.shields.io/badge/compatibility-${compatibilityScore}%25-${compatibilityColor}`
-}
+  return `https://img.shields.io/badge/compatibility-${compatibilityScore}%25-${compatibilityColor}`;
+};
 
 const createPullRequestMessage = (report) => `
 Bumps dependencies in \`template.json\` with most up to date versions as of today.
@@ -31,13 +38,18 @@ Bumps dependencies in \`template.json\` with most up to date versions as of toda
 ${report}
 </pre>
 </details>
-`
+`;
 
 const githubClient = new Octokit({
   auth: process.env.GITHUB_ACCESS_TOKEN
 });
 
 const gitClient = simpleGit(ROOT_PATH);
+
+const BRANCH_NAME = `chore/update-dependencies-${Date.now()}`;
+const PULL_REQUEST_TITLE = `chore(deps): daily update 'template.json'`;
+const REPOSITORY = 'create-contentful-app';
+const OWNER = 'contentful';
 
 (async function main() {
   const diffSummary = await gitClient.diffSummary();
@@ -47,30 +59,50 @@ const gitClient = simpleGit(ROOT_PATH);
     process.exit(0);
   }
 
-  const branch = `chore/update-dependencies-${Date.now()}`
-
   await gitClient
     .addConfig('user.name', 'Dependency Checker')
-    .addConfig('user.email', 'dependency-checker@contentful.org')
+    .addConfig('user.email', 'dependency-checker@contentful.org');
 
-  await gitClient.checkoutBranch(branch, 'master')
+  await gitClient.checkoutBranch(BRANCH_NAME, 'master');
 
-  await gitClient.add([TEMPLATE_PATH])
+  await gitClient.add([TEMPLATE_PATH]);
 
-  await gitClient.commit('chore(deps): update dependencies')
+  await gitClient.commit('chore(deps): update dependencies');
 
-  await gitClient.push(['-u', 'origin', branch])
+  await gitClient.push(['-u', 'origin', BRANCH_NAME]);
 
-  const testReport = validateAndRead(TEST_REPORT_PATH)
+  const testReport = validateAndRead(TEST_REPORT_PATH);
 
-  await githubClient.pulls.create({
-    owner: 'contentful',
-    repo: 'create-contentful-app',
-    title: `chore(deps): daily update 'template.json'`,
-    head: branch,
+  const { data: newPullRequest } = await githubClient.pulls.create({
+    owner: OWNER,
+    repo: REPOSITORY,
+    title: PULL_REQUEST_TITLE,
+    head: BRANCH_NAME,
     base: 'master',
     body: createPullRequestMessage(testReport)
   });
+
+  // Try closing previous Dependency Check Pull Requests, if any
+  const { data: pullRequests } = await githubClient.pulls.list({ owner: OWNER, repo: REPOSITORY, state: 'open' });
+
+  for (const pullRequest of pullRequests) {
+    if (pullRequest.title === PULL_REQUEST_TITLE) {
+      await githubClient.pulls.createReview({
+        owner: OWNER,
+        repo: REPOSITORY,
+        pull_number: pullRequest.number,
+        event: 'COMMENT',
+        body: `Closed in favor of #${newPullRequest.number}`
+      });
+
+      await githubClient.pulls.update({
+        owner: OWNER,
+        repo: REPOSITORY,
+        pull_number: pullRequest.number,
+        state: 'closed'
+      });
+    }
+  }
 })().catch(e => {
   printErrorAndExit('Unable to create a pull request', e);
 });

--- a/scripts/dependency-check/create-pull-request
+++ b/scripts/dependency-check/create-pull-request
@@ -1,0 +1,54 @@
+#! /bin/usr/env node
+
+const { Octokit } = require('@octokit/rest');
+const simpleGit = require('simple-git');
+const { printErrorAndExit, ROOT_PATH, printSuccess, TEMPLATE_PATH } = require('./utils');
+
+const githubClient = new Octokit({
+  auth: process.env.GITHUB_ACCESS_TOKEN
+});
+
+const gitClient = simpleGit(ROOT_PATH);
+
+(async function main() {
+  const diffSummary = await gitClient.diffSummary();
+
+  if (diffSummary.files.length === 0) {
+    printSuccess('Dependencies are up to date! Not creating a pull request');
+    process.exit(0);
+  }
+
+  const branch = `chore/update-dependencies-${Date.now()}`
+
+  await gitClient
+    .addConfig('user.name', 'Dependency Checker')
+    .addConfig('user.email', 'dependency-checker@contentful.org')
+
+  await gitClient.checkoutBranch(branch, 'master')
+
+  await gitClient.add([TEMPLATE_PATH])
+
+  // TODO: 
+  //   if we decide to do this one dependency at time, 
+  //   this should include dependency name and version
+  await gitClient.commit('chore(deps): update dependencies')
+
+  await gitClient.push(['-u', 'origin', branch])
+
+  await githubClient.pulls.create({
+    owner: 'contentful',
+    repo: 'create-contentful-app',
+    title: `chore(deps): daily update 'template.json'`,
+    head: branch,
+    base: 'master',
+    // TODO: 
+    //   if we decide to do this one dependency at time, 
+    //   this should include dependency name and version
+    //   and possibly the changelog too
+    body: `
+      Bumps dependencies in \`template.json\` with latest packages as of today.
+    `
+  });
+})().catch(e => {
+  printErrorAndExit('Unable to create a pull request', e);
+});

--- a/scripts/dependency-check/create-template-from-outdated
+++ b/scripts/dependency-check/create-template-from-outdated
@@ -14,10 +14,6 @@ printHeader('Creating new template from outdated')
 for (const dependency of Object.entries(outdated)) {
   const [name, {latest}] = dependency
 
-  // TODO: 
-  //   if we decide to do this one dependency at time, 
-  //   this should check for differences and stop on the
-  //   first discrepancy
   if (template.package.dependencies[name] && !ignoredPackages.includes(name)) {
     template.package.dependencies[name] = `^${latest}`
   }

--- a/scripts/dependency-check/create-template-from-outdated
+++ b/scripts/dependency-check/create-template-from-outdated
@@ -1,0 +1,33 @@
+#! /usr/bin/env node
+
+const fs = require('fs')
+const {validateAndRequire, TEMPLATE_PATH, OUTDATED_PATH, printHeader, printInfo, printErrorAndExit, printSuccess} = require('./utils')
+
+// List of packages for which we don't want to have the dependency check
+const ignoredPackages = []
+
+const template = validateAndRequire(TEMPLATE_PATH);
+const outdated = validateAndRequire(OUTDATED_PATH);
+
+printHeader('Creating new template from outdated')
+
+for (const dependency of Object.entries(outdated)) {
+  const [name, {latest}] = dependency
+
+  // TODO: 
+  //   if we decide to do this one dependency at time, 
+  //   this should check for differences and stop on the
+  //   first discrepancy
+  if (template.package.dependencies[name] && !ignoredPackages.includes(name)) {
+    template.package.dependencies[name] = `^${latest}`
+  }
+}
+
+try {
+  printInfo('Writing new template...')
+  fs.writeFileSync(TEMPLATE_PATH, JSON.stringify(template, null, 2))
+} catch (e) {
+  printErrorAndExit(`Unable to write new template.`, e)
+}
+
+printSuccess(`Successfully created new template at ${TEMPLATE_PATH}`)

--- a/scripts/dependency-check/utils.js
+++ b/scripts/dependency-check/utils.js
@@ -1,0 +1,78 @@
+const path = require('path');
+const fs = require('fs');
+
+const ROOT_PATH = path.resolve(__dirname, '..', '..');
+const SANDBOX_PATH = path.resolve(ROOT_PATH, 'dependency-check');
+const TEMPLATE_PATH = path.join(ROOT_PATH, 'template.json');
+const OUTDATED_PATH = path.join(SANDBOX_PATH, 'outdated.json');
+
+const getStyledString = (style, string) => {
+  if (!process.stdout.hasColors()) {
+    return string
+  }
+
+  switch (style) {
+    case 'red':
+      return `\x1b[31m${string}\x1b[0m`
+    case 'yellow':
+      return `\x1b[33m${string}\x1b[0m`
+    case 'green':
+      return `\x1b[32m${string}\x1b[0m`
+    default:
+      string
+  }
+} 
+
+const printError = (error, details) => {
+  console.error('');
+  console.error(getStyledString('red', ` !!! ${error}`));
+  if (details) {
+    console.error('Details: ')
+    console.group()
+    console.error(details)
+    console.groupEnd()
+  }
+  console.error('');
+}
+
+const printErrorAndExit = (error, details, statusCode = 1) => {
+  printError(error, details);
+  process.exit(statusCode);
+}
+
+const printInfo = (message) => {
+  console.log(` > ${message}`);
+}
+
+const printHeader = (message) => {
+  console.log('');
+  console.log(getStyledString('yellow', ` > ${message} < `));
+  console.log('');
+}
+
+const printSuccess = (message) => {
+  console.log(getStyledString('green', ` ✓ ${message}`));
+}
+
+const validateAndRequire = (path) => {
+  try {
+    require.resolve(path);
+  } catch (e) {
+    printErrorAndExit(`Unable to find file at ${path}`);
+  }
+
+  return require(path);
+}
+
+module.exports = {
+  printError,
+  printErrorAndExit,
+  printInfo,
+  printHeader,
+  printSuccess,
+  validateAndRequire,
+  ROOT_PATH,
+  SANDBOX_PATH,
+  OUTDATED_PATH,
+  TEMPLATE_PATH
+}

--- a/scripts/dependency-check/utils.js
+++ b/scripts/dependency-check/utils.js
@@ -5,6 +5,7 @@ const ROOT_PATH = path.resolve(__dirname, '..', '..');
 const SANDBOX_PATH = path.resolve(ROOT_PATH, 'dependency-check');
 const TEMPLATE_PATH = path.join(ROOT_PATH, 'template.json');
 const OUTDATED_PATH = path.join(SANDBOX_PATH, 'outdated.json');
+const TEST_REPORT_PATH = path.join(SANDBOX_PATH, 'test-report');
 
 const getStyledString = (style, string) => {
   if (!process.stdout.hasColors()) {
@@ -64,6 +65,14 @@ const validateAndRequire = (path) => {
   return require(path);
 }
 
+const validateAndRead = (filePath) => {
+  try {
+    return fs.readFileSync(filePath, {encoding: 'utf-8'})
+  } catch (e) {
+    printErrorAndExit(`Unable to read file at ${path}`, e);
+  }
+}
+
 module.exports = {
   printError,
   printErrorAndExit,
@@ -71,8 +80,10 @@ module.exports = {
   printHeader,
   printSuccess,
   validateAndRequire,
+  validateAndRead,
   ROOT_PATH,
   SANDBOX_PATH,
   OUTDATED_PATH,
-  TEMPLATE_PATH
+  TEMPLATE_PATH,
+  TEST_REPORT_PATH
 }


### PR DESCRIPTION
## Context

This change is mean to provide the capability to update automatically dependencies in `template.json`.

Follows up from #18 

### Key differences with agreed approach

* **not using `init`**
  To perform `npm outdated` check we don't need the packages to be installed. Plus, creating a `package.json` from the template is super easy and this saves us a bunch of minutes of CI time

### Points to discuss

* **multiple dependencies**
  As we have agreed, this automation updates all the packages in the `template.json`. We might want to have fine grained control over which dependency gets updated and when.
* **ignored packages**
  I have added a list of packages we might want to ignore while performing this check. Currently is empty. Do you think it's something useful?

### To Dos

- [x] install updated dependencies, run tests and push the test report as the pull request description
- [x] cleanup stale PRs when creating new ones

---

I would like to get your opinion on the points to discuss before proceeding with the rest of the to-dos