### PR TITLE
fix: don't auto close PRs

### DIFF
--- a/scripts/dependency-check/create-pull-request
+++ b/scripts/dependency-check/create-pull-request
@@ -86,7 +86,7 @@ const OWNER = 'contentful';
   const { data: pullRequests } = await githubClient.pulls.list({ owner: OWNER, repo: REPOSITORY, state: 'open' });
 
   for (const pullRequest of pullRequests) {
-    if (pullRequest.title === PULL_REQUEST_TITLE) {
+    if (pullRequest.title === PULL_REQUEST_TITLE && pullRequest.number !== newPullRequest.number) {
       await githubClient.pulls.createReview({
         owner: OWNER,
         repo: REPOSITORY,


### PR DESCRIPTION
## Context

This is to prevent [this](https://github.com/contentful/create-contentful-app/pull/49):

* find old dependencies;
* create the PR;
* in the attempt to close old PRs it also closes the one just opened

