### PR TITLE
fix: don't open browser on start

### DIFF
--- a/template.json
+++ b/template.json
@@ -15,6 +15,9 @@
       "@types/react-dom": "^16.9.8",
       "contentful-ui-extensions-sdk": "^3.23.4",
       "typescript": "^4.0.3"
+    },
+    "scripts": {
+      "start": "BROWSER=none react-scripts start"
     }
   }
 }


### PR DESCRIPTION
This was confusing people, as the ui-extension-sdk doesn't work
unless run in an iFrame