### PR TITLE
fix: add forma-36 tokens css import

### DIFF
--- a/template/src/index.tsx
+++ b/template/src/index.tsx
@@ -14,6 +14,7 @@ import {
 } from 'contentful-ui-extensions-sdk';
 import '@contentful/forma-36-react-components/dist/styles.css';
 import '@contentful/forma-36-fcss/dist/styles.css';
+import '@contentful/forma-36-tokens/dist/css/index.css';
 import './index.css';
 
 import Config from './components/ConfigScreen';


### PR DESCRIPTION
Fixing issue that was raised by #140 

While these styles aren't used directly by the default app template, I think it's worth importing these styles to make it easier for people to use other Forma components. 