### PR TITLE
fix: use cross-env in start command

### DIFF
--- a/template.json
+++ b/template.json
@@ -14,10 +14,11 @@
       "@types/react": "^16.9.55",
       "@types/react-dom": "^16.9.9",
       "contentful-ui-extensions-sdk": "^3.24.0",
-      "typescript": "^4.0.5"
+      "typescript": "^4.0.5",
+      "cross-env": "^6.0.3"
     },
     "scripts": {
-      "start": "BROWSER=none react-scripts start"
+      "start": "cross-env BROWSER=none react-scripts start"
     }
   }
 }


### PR DESCRIPTION
The script failed on most windows shells. Cross-env ensures that it will
work across platforms.

This was raised in #160 