### PR TITLE
Improve CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@ orbs:
 jobs:
   dependency-check:
     docker:
-      - image: node:12
-        environment:
-          NPM_CONFIG_PROGRESS: 'false'
-          NPM_CONFIG_LOGLEVEL: warn
+       - image: node:12
+         environment:
+            NPM_CONFIG_PROGRESS: 'false'
+            NPM_CONFIG_LOGLEVEL: warn
     steps:
       - checkout
       - run:
@@ -43,8 +43,8 @@ jobs:
           command: rm -rf ./dependency-check
 
   lint-and-test:
-    executor:
-      name: node/default
+    docker:
+       - image: node:15
     parameters:
       node-version:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,15 @@
 version: 2.1
 
-environment: &base-env
-    NPM_CONFIG_PROGRESS: 'false'
-    NPM_CONFIG_LOGLEVEL: warn
-    
-executors:
-  node-container:
-    docker:
-      - image: node:12
-        environment: *base-env
-
-  node-container-next-lts:
-    docker:
-      - image: node:14
-        environment: *base-env
+orbs:
+  node: circleci/node@4.1.0
 
 jobs:
   dependency-check:
-    executor: node-container
+    docker:
+      - image: node:12
+        environment:
+          NPM_CONFIG_PROGRESS: 'false'
+          NPM_CONFIG_LOGLEVEL: warn
     steps:
       - checkout
       - run:
@@ -50,10 +42,17 @@ jobs:
           name: Cleanup
           command: rm -rf ./dependency-check
 
-  lint-and-test: &lint-and-test
-    executor: node-container
+  lint-and-test:
+    executor:
+      name: node/default
+    parameters:
+      node-version:
+        type: string
     steps:
       - checkout
+      - node/install:
+          node-version: << parameters.node-version >>
+      - node/install-packages
       - run:
           name: Install Dependencies
           command: npm ci
@@ -62,31 +61,18 @@ jobs:
           command: npm run lint
       - run:
           name: Run Tests
-          command: npm t
-
-  lint-and-test-next-lts:
-    <<: *lint-and-test
-    executor: node-container-next-lts
-
-  test-built-app: &test-built-app
-    executor: node-container
-    steps:
-      - checkout
+          command: npm test
       - run:
-          name: Run Tests
+          name: Build app and run its tests
           environment:
-            MODE: 'ci'
+            MODE: 'local'
           command: |
             PROJECT=test-$(date +%s)
-            mkdir "${TMPDIR}/${PROJECT}"
-            cd "${TMPDIR}/${PROJECT}"
-            npx @contentful/create-contentful-app init test
-            cd test
-            npm t
-  
-  test-built-app-next-lts:
-    <<: *test-built-app
-    executor: node-container-next-lts
+            node lib/index.js init $PROJECT
+            cd $PROJECT
+            npm test
+            cd ..
+            rm -r $PROJECT
 
 workflows:
   version: 2
@@ -95,7 +81,7 @@ workflows:
     triggers:
       - schedule:
           # Run each day at midnight
-          cron: "0 0 * * *"
+          cron: '0 0 * * *'
           filters:
             branches:
               only: master
@@ -104,13 +90,10 @@ workflows:
 
   test:
     jobs:
-      - lint-and-test
-      - lint-and-test-next-lts
-      - test-built-app:
-          requires:
-            - lint-and-test
-            - lint-and-test-next-lts
-      - test-built-app-next-lts:
-          requires:
-            - lint-and-test
-            - lint-and-test-next-lts
+      - lint-and-test:
+          matrix:
+            parameters:
+              node-version:
+                - '15'
+                - '14'
+                - '12'


### PR DESCRIPTION
I started this PR because node 15 currently doesn't fully work.

There are multiple issues in the CI config:
- `test-built-app` only tests current master and not the current
  revision
- node 15 is not tested
- Multiple node versions add complexity to the ci config

I use the official node orb as it makes life easier.

With this PR I slightly refactor the config and use a parameter matrix
to run jobs with multiple node versions. Also, the tests always use the
current revision and not what is currently deployed on npm.
Also, I combined both tests to avoid having to install dependencies
twice.

## ToDo:

- [ ] We currently don't specify the npm version which means that we don't test npm 7. Probably we should?