### PR TITLE
Run tests with node 15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,10 +147,7 @@ workflows:
             - lint-and-test-next-lts
 
       - lint-and-test-latest
-      - test-built-app-latest:
-          requires:
-            - lint-and-test-latest
-          pre-steps:
-            - run:
-                name: Install npm 7.1 as npx in 7.0 does not work
-                command: npm i -g npm@7.1.0
+      # npx currently fails with the latest node version (15.3.0)
+      # - test-built-app-latest:
+      #     requires:
+      #       - lint-and-test-latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ commands:
           name: Install Dependencies
           command: npm ci
       - run:
+          name: Link package
+          command: npm link
+      - run:
           name: Run Tests
           environment:
             MODE: 'ci'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,3 +150,7 @@ workflows:
       - test-built-app-latest:
           requires:
             - lint-and-test-latest
+          pre-steps:
+            - run:
+                name: Install npm 7.1 as npx in 7.0 does not work
+                command: npm i -g npm@7.1.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,9 @@ commands:
     steps:
       - checkout
       - run:
+          name: Install Dependencies
+          command: npm ci
+      - run:
           name: Run Tests
           environment:
             MODE: 'ci'
@@ -45,7 +48,7 @@ commands:
             PROJECT=test-$(date +%s)
             mkdir "${TMPDIR}/${PROJECT}"
             cd "${TMPDIR}/${PROJECT}"
-            npx @contentful/create-contentful-app init test
+            npx --no-install @contentful/create-contentful-app init test
             cd test
             npm t
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,57 @@
 version: 2.1
 
 environment: &base-env
-    NPM_CONFIG_PROGRESS: 'false'
-    NPM_CONFIG_LOGLEVEL: warn
-    
+  NPM_CONFIG_PROGRESS: 'false'
+  NPM_CONFIG_LOGLEVEL: warn
+
 executors:
-  node-container:
+  node-container-12:
     docker:
       - image: node:12
         environment: *base-env
 
-  node-container-next-lts:
+  node-container-14:
     docker:
       - image: node:14
         environment: *base-env
 
+  node-container-15:
+    docker:
+      - image: node:15
+        environment: *base-env
+
+commands:
+  lint-and-test:
+    steps:
+      - checkout
+      - run:
+          name: Install Dependencies
+          command: npm ci
+      - run:
+          name: Run Linter
+          command: npm run lint
+      - run:
+          name: Run Tests
+          command: npm t
+
+  test-built-app:
+    steps:
+      - checkout
+      - run:
+          name: Run Tests
+          environment:
+            MODE: 'ci'
+          command: |
+            PROJECT=test-$(date +%s)
+            mkdir "${TMPDIR}/${PROJECT}"
+            cd "${TMPDIR}/${PROJECT}"
+            npx @contentful/create-contentful-app init test
+            cd test
+            npm t
+
 jobs:
   dependency-check:
-    executor: node-container
+    executor: node-container-12
     steps:
       - checkout
       - run:
@@ -50,43 +84,35 @@ jobs:
           name: Cleanup
           command: rm -rf ./dependency-check
 
-  lint-and-test: &lint-and-test
-    executor: node-container
+  lint-and-test-12:
+    executor: node-container-12
     steps:
-      - checkout
-      - run:
-          name: Install Dependencies
-          command: npm ci
-      - run:
-          name: Run Linter
-          command: npm run lint
-      - run:
-          name: Run Tests
-          command: npm t
+      - lint-and-test
 
-  lint-and-test-next-lts:
-    <<: *lint-and-test
-    executor: node-container-next-lts
-
-  test-built-app: &test-built-app
-    executor: node-container
+  lint-and-test-14:
+    executor: node-container-14
     steps:
-      - checkout
-      - run:
-          name: Run Tests
-          environment:
-            MODE: 'ci'
-          command: |
-            PROJECT=test-$(date +%s)
-            mkdir "${TMPDIR}/${PROJECT}"
-            cd "${TMPDIR}/${PROJECT}"
-            npx @contentful/create-contentful-app init test
-            cd test
-            npm t
-  
-  test-built-app-next-lts:
-    <<: *test-built-app
-    executor: node-container-next-lts
+      - lint-and-test
+
+  lint-and-test-15:
+    executor: node-container-15
+    steps:
+      - lint-and-test
+
+  test-built-app-12:
+    executor: node-container-12
+    steps:
+      - test-built-app
+
+  test-built-app-14:
+    executor: node-container-14
+    steps:
+      - test-built-app
+
+  test-built-app-15:
+    executor: node-container-15
+    steps:
+      - test-built-app
 
 workflows:
   version: 2
@@ -95,7 +121,7 @@ workflows:
     triggers:
       - schedule:
           # Run each day at midnight
-          cron: "0 0 * * *"
+          cron: '0 0 * * *'
           filters:
             branches:
               only: master
@@ -104,13 +130,17 @@ workflows:
 
   test:
     jobs:
-      - lint-and-test
-      - lint-and-test-next-lts
-      - test-built-app:
+      - lint-and-test-12
+      - test-built-app-12:
           requires:
-            - lint-and-test
-            - lint-and-test-next-lts
-      - test-built-app-next-lts:
+            - lint-and-test-12
+
+      - lint-and-test-14
+      - test-built-app-14:
           requires:
-            - lint-and-test
-            - lint-and-test-next-lts
+            - lint-and-test-14
+
+      - lint-and-test-15
+      - test-built-app-15:
+          requires:
+            - lint-and-test-15

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,17 +5,17 @@ environment: &base-env
   NPM_CONFIG_LOGLEVEL: warn
 
 executors:
-  node-container-12:
+  node-container-lts:
     docker:
       - image: node:12
         environment: *base-env
 
-  node-container-14:
+  node-container-next-lts:
     docker:
       - image: node:14
         environment: *base-env
 
-  node-container-15:
+  node-container-latest:
     docker:
       - image: node:15
         environment: *base-env
@@ -54,7 +54,7 @@ commands:
 
 jobs:
   dependency-check:
-    executor: node-container-12
+    executor: node-container-lts
     steps:
       - checkout
       - run:
@@ -87,33 +87,33 @@ jobs:
           name: Cleanup
           command: rm -rf ./dependency-check
 
-  lint-and-test-12:
-    executor: node-container-12
+  lint-and-test-lts:
+    executor: node-container-lts
     steps:
       - lint-and-test
 
-  lint-and-test-14:
-    executor: node-container-14
+  lint-and-test-next-lts:
+    executor: node-container-next-lts
     steps:
       - lint-and-test
 
-  lint-and-test-15:
-    executor: node-container-15
+  lint-and-test-latest:
+    executor: node-container-latest
     steps:
       - lint-and-test
 
-  test-built-app-12:
-    executor: node-container-12
+  test-built-app-lts:
+    executor: node-container-lts
     steps:
       - test-built-app
 
-  test-built-app-14:
-    executor: node-container-14
+  test-built-app-next-lts:
+    executor: node-container-next-lts
     steps:
       - test-built-app
 
-  test-built-app-15:
-    executor: node-container-15
+  test-built-app-latest:
+    executor: node-container-latest
     steps:
       - test-built-app
 
@@ -133,17 +133,17 @@ workflows:
 
   test:
     jobs:
-      - lint-and-test-12
-      - test-built-app-12:
+      - lint-and-test-lts
+      - test-built-app-lts:
           requires:
-            - lint-and-test-12
+            - lint-and-test-lts
 
-      - lint-and-test-14
-      - test-built-app-14:
+      - lint-and-test-next-lts
+      - test-built-app-next-lts:
           requires:
-            - lint-and-test-14
+            - lint-and-test-next-lts
 
-      - lint-and-test-15
-      - test-built-app-15:
+      - lint-and-test-latest
+      - test-built-app-latest:
           requires:
-            - lint-and-test-15
+            - lint-and-test-latest


### PR DESCRIPTION
The original intent behind this PR was to also run the tests with node 15 as `npx @contentful/create-contentful-app` was failing there. Unfortunately, the CI currently crashes when running `npx` with node 15, so we cannot actually test that. This might be fixed with node 7.1.0.

But what this PR does include is
- running the basic tests with node 15
- actually testing the local changes in `test-built-app` and not the current latest version on npm