### PR TITLE
fix: return correct exit code when init fails

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,7 @@ function initProject() {
       if (exitCode === 0) {
         onSuccess(appFolder);
       } else {
-        process.exit();
+        process.exit(exitCode);
       }
     });
   } catch (err) {
@@ -77,6 +77,7 @@ function initProject() {
 
       ${err}
       `);
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
We currently only exit with a non-0 code when the app name is missing.
With this PR we forward the exit codes of create-react-app and also fail with exit code `1` in case of any other error.

This will fix the programmatic use of the package e.g. in our CI.