### PR TITLE
Fix dependency check job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,18 +74,26 @@ jobs:
           name: Create new template
           command: node ./scripts/dependency-check/create-template-from-outdated
       - run:
+          name: Install Dependencies
+          command: npm ci
+      - run:
+          name: Link package
+          command: npm link
+      - run:
           name: Run Tests and Produce Reports
           command: |
             FORMER_CWD="$(pwd)"
             PROJECT=test-$(date +%s)
             mkdir "${TMPDIR}/${PROJECT}"
             cd "${TMPDIR}/${PROJECT}"
-            npx @contentful/create-contentful-app init test
+            npx --no-install @contentful/create-contentful-app init test
             cd test
-            (CI=true npm t || true) 1>"${FORMER_CWD}/dependency-check/test-report" 2>&1
+            (npm t || true) 1>"${FORMER_CWD}/dependency-check/test-report" 2>&1
+          environment:
+            MODE: 'local'
       - run:
-          name: Create Pull Request
-          command: npm install @octokit/rest@18 simple-git@2 && node ./scripts/dependency-check/create-pull-request
+         name: Create Pull Request
+         command: npm install @octokit/rest@18 simple-git@2 && node ./scripts/dependency-check/create-pull-request
       - run:
           name: Cleanup
           command: rm -rf ./dependency-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,8 +92,8 @@ jobs:
           environment:
             MODE: 'local'
       - run:
-         name: Create Pull Request
-         command: npm install @octokit/rest@18 simple-git@2 && node ./scripts/dependency-check/create-pull-request
+          name: Create Pull Request
+          command: npm install @octokit/rest@18 simple-git@2 && node ./scripts/dependency-check/create-pull-request
       - run:
           name: Cleanup
           command: rm -rf ./dependency-check


### PR DESCRIPTION
### Purpose

The daily dependency-check job was failing with

```
Error: Cannot find module 'file:/Users/<user>/.npm/_npx/75677/lib/node_modules//package.json'
Require stack:
- /Users/<user>/dev/create-contentful-app/blaaaa/test/node_modules/react-scripts/scripts/init.js
- /Users/<user>/dev/create-contentful-app/blaaaa/test/[eval]
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:815:15)
    at Function.resolve (internal/modules/cjs/helpers.js:80:19)
    at module.exports (/Users/<user>/dev/create-contentful-app/blaaaa/test/node_modules/react-scripts/scripts/init.js:117:13)
    at [eval]:3:14
    at Script.runInThisContext (vm.js:120:18)
    at Object.runInThisContext (vm.js:309:38)
    at Object.<anonymous> ([eval]-wrapper:10:26)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at evalScript (internal/process/execution.js:94:25)
    at internal/main/eval_string.js:23:3 {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/<user>/dev/create-contentful-app/blaaaa/test/node_modules/react-scripts/scripts/init.js',
    '/Users/<user>/dev/create-contentful-app/blaaaa/test/[eval]'
  ]
}
```

The job started failing from November 4. There is no code change that triggered this but the `MODE=local` env variable being added to the project configuration. As this was very hard to find, I added `MODE=local` to the config.yml and removed the project setting. That this variable wasn't set before means that before Nov 4, we didn't actually test the updated template.json before creating the PR but only tested whether the currently published version works with their published template.json.

The error occurrs because using the published package with `MODE=local` doesn't work well together. `MODE=local` relies on being executed in a specific folder with the updated template.json just one level above. When running `npx` with the published version, the package is loaded into a temporary directory, `__dirname` is not set as expected and the template cannot be found leading to the error above.

There are now two options: 
* Either always run the local version of the package and try to pass in a path in order to specify the local updated template,
* or run the local version of the package

The second option is the easiest and as the current master is (hopefully) always identical to the published version, there shouldn't be much difference. Also, it makes more sense to ensure that the current `master` works with the updated dependencies than ensuring the published version works with it. We always update the template and cca together, so there should not be any issues.

To fix the problem, I did the following:
* install and link the package
* run npx with `--no-install`
* add MODE=local as explained above


### Minor cleanup
I removed `CI=true` as this env variable is always set in CI services including circleci and only adds unnecessary code.