### PR TITLE
feat: use @contentful/app-sdk

### DIFF
--- a/template.json
+++ b/template.json
@@ -1,6 +1,7 @@
 {
   "package": {
     "dependencies": {
+      "@contentful/app-sdk": "^3.31.0",
       "@contentful/field-editor-single-line": "^0.11.4",
       "@contentful/field-editor-test-utils": "^0.8.3",
       "@contentful/forma-36-fcss": "^0.2.12",
@@ -13,7 +14,6 @@
       "@types/node": "^14.14.19",
       "@types/react": "^17.0.0",
       "@types/react-dom": "^17.0.0",
-      "contentful-ui-extensions-sdk": "^3.26.1",
       "typescript": "^4.1.3",
       "cross-env": "^7.0.3"
     },

--- a/template/src/components/ConfigScreen.tsx
+++ b/template/src/components/ConfigScreen.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { AppExtensionSDK } from 'contentful-ui-extensions-sdk';
+import { AppExtensionSDK } from '@contentful/app-sdk';
 import { Heading, Form, Workbench, Paragraph } from '@contentful/forma-36-react-components';
 import { css } from 'emotion';
 
@@ -50,7 +50,7 @@ export default class Config extends Component<ConfigProps, ConfigState> {
       parameters: this.state.parameters,
       // In case you don't want to submit any update to app
       // locations, you can just pass the currentState as is
-      targetState: currentState
+      targetState: currentState,
     };
   };
 

--- a/template/src/components/Dialog.tsx
+++ b/template/src/components/Dialog.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Paragraph } from '@contentful/forma-36-react-components';
-import { DialogExtensionSDK } from 'contentful-ui-extensions-sdk';
+import { DialogExtensionSDK } from '@contentful/app-sdk';
 
 interface DialogProps {
   sdk: DialogExtensionSDK;

--- a/template/src/components/EntryEditor.tsx
+++ b/template/src/components/EntryEditor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Paragraph } from '@contentful/forma-36-react-components';
-import { EditorExtensionSDK } from 'contentful-ui-extensions-sdk';
+import { EditorExtensionSDK } from '@contentful/app-sdk';
 
 interface EditorProps {
   sdk: EditorExtensionSDK;

--- a/template/src/components/Field.tsx
+++ b/template/src/components/Field.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Paragraph } from '@contentful/forma-36-react-components';
-import { FieldExtensionSDK } from 'contentful-ui-extensions-sdk';
+import { FieldExtensionSDK } from '@contentful/app-sdk';
 
 interface FieldProps {
   sdk: FieldExtensionSDK;

--- a/template/src/components/Page.tsx
+++ b/template/src/components/Page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Paragraph } from '@contentful/forma-36-react-components';
-import { PageExtensionSDK } from 'contentful-ui-extensions-sdk';
+import { PageExtensionSDK } from '@contentful/app-sdk';
 
 interface PageProps {
   sdk: PageExtensionSDK;

--- a/template/src/components/Sidebar.tsx
+++ b/template/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Paragraph } from '@contentful/forma-36-react-components';
-import { SidebarExtensionSDK } from 'contentful-ui-extensions-sdk';
+import { SidebarExtensionSDK } from '@contentful/app-sdk';
 
 interface SidebarProps {
   sdk: SidebarExtensionSDK;

--- a/template/src/index.tsx
+++ b/template/src/index.tsx
@@ -10,7 +10,7 @@ import {
   PageExtensionSDK,
   init,
   locations,
-} from 'contentful-ui-extensions-sdk';
+} from '@contentful/app-sdk';
 import '@contentful/forma-36-react-components/dist/styles.css';
 import '@contentful/forma-36-fcss/dist/styles.css';
 import '@contentful/forma-36-tokens/dist/css/index.css';


### PR DESCRIPTION
Replace `contentful-ui-extensions-sdk` with `@contentful/app-sdk`.
Both packages are identical but the App SDK should be used for apps.