### PR TITLE
fix: remove explicit types from init call

### DIFF
--- a/template/src/index.tsx
+++ b/template/src/index.tsx
@@ -8,9 +8,8 @@ import {
   DialogExtensionSDK,
   EditorExtensionSDK,
   PageExtensionSDK,
-  BaseExtensionSDK,
   init,
-  locations
+  locations,
 } from 'contentful-ui-extensions-sdk';
 import '@contentful/forma-36-react-components/dist/styles.css';
 import '@contentful/forma-36-fcss/dist/styles.css';
@@ -31,7 +30,7 @@ if (process.env.NODE_ENV === 'development' && window.self === window.top) {
   const root = document.getElementById('root');
   render(<LocalhostWarning />, root);
 } else {
-  init((sdk: BaseExtensionSDK) => {
+  init((sdk) => {
     const root = document.getElementById('root');
 
     // All possible locations for your app
@@ -40,32 +39,32 @@ if (process.env.NODE_ENV === 'development' && window.self === window.top) {
     const ComponentLocationSettings = [
       {
         location: locations.LOCATION_APP_CONFIG,
-        component: <Config sdk={(sdk as unknown) as AppExtensionSDK} />
+        component: <Config sdk={sdk as AppExtensionSDK} />,
       },
       {
         location: locations.LOCATION_ENTRY_FIELD,
-        component: <Field sdk={(sdk as unknown) as FieldExtensionSDK} />
+        component: <Field sdk={sdk as FieldExtensionSDK} />,
       },
       {
         location: locations.LOCATION_ENTRY_EDITOR,
-        component: <EntryEditor sdk={(sdk as unknown) as EditorExtensionSDK} />
+        component: <EntryEditor sdk={sdk as EditorExtensionSDK} />,
       },
       {
         location: locations.LOCATION_DIALOG,
-        component: <Dialog sdk={(sdk as unknown) as DialogExtensionSDK} />
+        component: <Dialog sdk={sdk as DialogExtensionSDK} />,
       },
       {
         location: locations.LOCATION_ENTRY_SIDEBAR,
-        component: <Sidebar sdk={(sdk as unknown) as SidebarExtensionSDK} />
+        component: <Sidebar sdk={sdk as SidebarExtensionSDK} />,
       },
       {
         location: locations.LOCATION_PAGE,
-        component: <Page sdk={(sdk as unknown) as PageExtensionSDK} />
-      }
+        component: <Page sdk={sdk as PageExtensionSDK} />,
+      },
     ];
 
     // Select a component depending on a location in which the app is rendered.
-    ComponentLocationSettings.forEach(componentLocationSetting => {
+    ComponentLocationSettings.forEach((componentLocationSetting) => {
       if (sdk.location.is(componentLocationSetting.location)) {
         render(componentLocationSetting.component, root);
       }


### PR DESCRIPTION
The `sdk` is of type `KnownSDK` and not `BaseExtensionSDK`. Therefore, we might run into type issues in the future.
I removed it which means I can also remove the ugly `as unknown`s.