### PR TITLE
feat: directly forward logs from npx process

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,23 +49,12 @@ function initProject() {
 
     const args = [createReactApp, appFolder, '--template', templatePkg, '--use-npm'];
 
-    // start creating app
-    const appCreateProcess = spawn(initCommand, args);
-
-    appCreateProcess.stdout.on('data', data => {
-      console.log(data.toString());
-    });
-
-    appCreateProcess.stderr.on('data', data => {
-      console.log('\n');
-      console.error(data.toString());
-    });
-
     console.log(
       `Creating a Contentful app in ${chalk.bold(tildify(path.resolve(process.cwd(), appFolder)))}.`
     );
 
-    appCreateProcess.on('exit', exitCode => {
+    const appCreateProcess = spawn(initCommand, args, { stdio: 'inherit' });
+    appCreateProcess.on('exit', (exitCode) => {
       if (exitCode === 0) {
         onSuccess(appFolder);
       } else {


### PR DESCRIPTION
We currently use `.stderr.on('data', [...])` and `.stdout.on('data', [...])` and put the data in `console.log`. That removes color and adds additional new lines

By using `{ stdio: 'inherit' }` we can forward the data directly to stdout.
> Pass through the corresponding stdio stream to/from the parent process. 

That way
- we keep the log color
- we don't add additional empty lines
- the output is prettier and easier to read


# Before
## Success

<img width="724" alt="Screenshot 2021-01-15 at 14 57 59" src="https://user-images.githubusercontent.com/4947671/104735605-12373c80-5742-11eb-8cf6-6e57632ccc62.png">
<img width="436" alt="Screenshot 2021-01-15 at 14 58 18" src="https://user-images.githubusercontent.com/4947671/104735641-1c593b00-5742-11eb-93d0-07da9fa55aa0.png">


## Error

<img width="536" alt="Screenshot 2021-01-15 at 14 56 02" src="https://user-images.githubusercontent.com/4947671/104735380-cbe1dd80-5741-11eb-8412-41e79fa278cb.png">


# After
## Success

<img width="702" alt="Screenshot 2021-01-15 at 14 54 59" src="https://user-images.githubusercontent.com/4947671/104735230-a6ed6a80-5741-11eb-8109-dbb1d2ef6e9a.png">


## Error

<img width="523" alt="Screenshot 2021-01-15 at 14 55 39" src="https://user-images.githubusercontent.com/4947671/104735309-be2c5800-5741-11eb-9270-55396a70e516.png">
