### PR TITLE
feat: Clarify supported node/npm versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This project makes it easy to bootstrap [Contentful Apps](https://www.contentful
 
 ## Requirements
 
-Node.js 12 or higher
+- Node.js v12 or v14
+- NPM v6
 
 # Quick Overview
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "url": "https://github.com/contentful/create-contentful-app.git"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=12 <15",
+    "npm": ">=6 <7"
   },
   "main": "template.json",
   "files": [


### PR DESCRIPTION
Still doesn't warn when using `npx` though