### PR TITLE
chore: delete branches of old dep-check PRs

### DIFF
--- a/scripts/dependency-check/create-pull-request
+++ b/scripts/dependency-check/create-pull-request
@@ -87,11 +87,10 @@ const OWNER = 'contentful';
 
   for (const pullRequest of pullRequests) {
     if (pullRequest.title === PULL_REQUEST_TITLE && pullRequest.number !== newPullRequest.number) {
-      await githubClient.pulls.createReview({
+      await githubClient.issues.createComment({
         owner: OWNER,
         repo: REPOSITORY,
         pull_number: pullRequest.number,
-        event: 'COMMENT',
         body: `Closed in favor of #${newPullRequest.number}`
       });
 
@@ -101,6 +100,12 @@ const OWNER = 'contentful';
         pull_number: pullRequest.number,
         state: 'closed'
       });
+
+      await githubClient.git.deleteRef({
+        owner: OWNER,
+        repo: REPOSITORY,
+        ref: `heads/${pr.head.ref}`
+      })
     }
   }
 })().catch(e => {


### PR DESCRIPTION
We are currently only closing old PRs but do not delete the corresponding branches.
Therefore, we currently have 46 open branches in this repo.

This PR automatically deletes the branch when closing the PR.
Also, the comment is now a regular comment instead of a "review comment". That way the PR now looks the same as if a regular user typed something in the comments box, clicked "Close with comment" and then deleted the branch.