### PR TITLE
chore: auto merge dep-check PRs [EXT-2537]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,12 @@ jobs:
     executor: node-container-lts
     steps:
       - checkout
+      - run: 
+          name: Install additional dependencies
+          command: npm install @octokit/rest@18 simple-git@2
+      - run:
+          name: Merge Pull Request
+          command: node ./scripts/dependency-check/merge-pull-request.js
       - run:
           name: Create Dependency Check sandbox
           command: mkdir -p ./dependency-check
@@ -93,7 +99,7 @@ jobs:
             MODE: 'local'
       - run:
           name: Create Pull Request
-          command: npm install @octokit/rest@18 simple-git@2 && node ./scripts/dependency-check/create-pull-request
+          command: node ./scripts/dependency-check/create-pull-request
       - run:
           name: Cleanup
           command: rm -rf ./dependency-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,6 @@ jobs:
     executor: node-container-lts
     steps:
       - checkout
-      - run: 
-          name: Install additional dependencies
-          command: npm install @octokit/rest@18 simple-git@2
       - run:
           name: Merge Pull Request
           command: node ./scripts/dependency-check/merge-pull-request.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -561,6 +561,162 @@
         }
       }
     },
+    "@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1"
+      }
+    },
+    "@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "dev": true
+    },
+    "@octokit/auth-token": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "@octokit/core": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.3.1.tgz",
+      "integrity": "sha512-Dc5NNQOYjgZU5S1goN6A/E500yXOfDUFRGQB8/2Tl16AcfvS3H9PudyOe3ZNE/MaVyHPIfC0htReHMJb1tMrvw==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.4.12",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.11.tgz",
+      "integrity": "sha512-fUIPpx+pZyoLW4GCs3yMnlj2LfoXTWDUVPTC4V3MUEKZm48W+XYpeWSZCv+vYF1ZABUm2CqnDVf1sFtIYrj7KQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/graphql": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.6.1.tgz",
+      "integrity": "sha512-2lYlvf4YTDgZCTXTW4+OX+9WTLFtEUc6hGm4qM1nlZjzxj+arizM4aHWzBVBCxY9glh7GIs0WEuiSgbVzv8cmA==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^5.3.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-6.0.0.tgz",
+      "integrity": "sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ==",
+      "dev": true
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.3.tgz",
+      "integrity": "sha512-46lptzM9lTeSmIBt/sVP/FLSTPGx6DCzAdSX3PfeJ3mTf4h9sGC26WpaQzMEq/Z44cOcmx8VsOhO+uEgE3cjYg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.11.0"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz",
+      "integrity": "sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==",
+      "dev": true
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-4.15.0.tgz",
+      "integrity": "sha512-1AF9GM/Ywk8ukUM5seDRj286GdFpdfsHeOrOPBV2rVtRN7MQNzRIcw8W5sb4JPerjQ0WcRRwAwQyufg64BxJkA==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.13.0",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.14.tgz",
+      "integrity": "sha512-VkmtacOIQp9daSnBmDI92xNIeLuSRDOIuplp/CJomkvzt7M18NXgG044Cx/LFKLgjKt9T2tZR6AtJayba9GTSA==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.0.0",
+        "@octokit/types": "^6.7.1",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "once": "^1.4.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.5.tgz",
+      "integrity": "sha512-T/2wcCFyM7SkXzNoyVNWjyVlUwBvW3igM3Btr/eKYiPmucXTtkxt2RBsf6gn3LTzaLSLTQtNmvg+dGsOxQrjZg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "18.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.5.0.tgz",
+      "integrity": "sha512-+4+u12KIw53R9+k6jBw6QL7xycKfEquk8CuStNNjdSPxCC7+FQiULG/woyqgJaGod6zBkYGSL0Zulk4JM8h2sQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/core": "^3.2.3",
+        "@octokit/plugin-paginate-rest": "^2.6.2",
+        "@octokit/plugin-request-log": "^1.0.2",
+        "@octokit/plugin-rest-endpoint-methods": "4.15.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.13.0.tgz",
+      "integrity": "sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==",
+      "dev": true,
+      "requires": {
+        "@octokit/openapi-types": "^6.0.0"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
@@ -857,6 +1013,12 @@
           }
         }
       }
+    },
+    "before-after-hook": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.0.tgz",
+      "integrity": "sha512-jH6rKQIfroBbhEXVmI7XmXe3ix5S/PgJqpzdDPnR8JGLHWNYLsYZ6tK5iWOF/Ra3oqEX0NobXGlzbiylIzVphQ==",
+      "dev": true
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -1956,6 +2118,12 @@
           }
         }
       }
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true
     },
     "detect-file": {
       "version": "1.0.0",
@@ -3928,6 +4096,12 @@
         "path-to-regexp": "^1.7.0"
       }
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
     "normalize-package-data": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
@@ -4633,6 +4807,34 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
+    "simple-git": {
+      "version": "2.37.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.37.0.tgz",
+      "integrity": "sha512-ZK6qRnP+Xa2v23UEZDNHUfzswsuNCDHOQpWZRkpqNaXn7V5wVBBx3zRJLji3pROJGzrzA7mXwY7preL5EKuAaQ==",
+      "dev": true,
+      "requires": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "sinon": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.0.tgz",
@@ -5268,6 +5470,12 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
+    },
+    "universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+      "dev": true
     },
     "universalify": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   "devDependencies": {
     "@commitlint/cli": "^12.0.0",
     "@commitlint/config-conventional": "12.0.1",
+    "@octokit/rest": "18.5.0",
     "babel-eslint": "10.1.0",
     "commitizen": "^4.0.3",
     "cz-customizable": "6.3.0",
@@ -80,6 +81,7 @@
     "mocha": "^8.2.1",
     "prettier": "2.2.1",
     "proxyquire": "^2.1.3",
+    "simple-git": "2.37.0",
     "sinon": "^10.0.0"
   }
 }

--- a/scripts/dependency-check/create-pull-request
+++ b/scripts/dependency-check/create-pull-request
@@ -82,6 +82,13 @@ const OWNER = 'contentful';
     body: createPullRequestMessage(testReport)
   });
 
+  await githubClient.issues.addLabels({
+    owner: OWNER,
+    repo: REPOSITORY,
+    issue_number: newPullRequest.number,
+    labels: ['dependencies']
+  })
+
   // Try closing previous Dependency Check Pull Requests, if any
   const { data: pullRequests } = await githubClient.pulls.list({ owner: OWNER, repo: REPOSITORY, state: 'open' });
 

--- a/scripts/dependency-check/create-pull-request
+++ b/scripts/dependency-check/create-pull-request
@@ -1,15 +1,16 @@
 #! /bin/usr/env node
 
-const { Octokit } = require('@octokit/rest');
-const simpleGit = require('simple-git');
-
 const {
   TEMPLATE_PATH,
   TEST_REPORT_PATH,
-  ROOT_PATH,
   printErrorAndExit,
   printSuccess,
-  validateAndRead
+  validateAndRead,
+  createGitClient,
+  createGithubClient,
+  PULL_REQUEST_TITLE,
+  OWNER,
+  REPOSITORY
 } = require('./utils');
 
 const getCompatibilityBadge = (report) => {
@@ -40,16 +41,9 @@ ${report}
 </details>
 `;
 
-const githubClient = new Octokit({
-  auth: process.env.GITHUB_ACCESS_TOKEN
-});
-
-const gitClient = simpleGit(ROOT_PATH);
-
+const githubClient = createGithubClient();
+const gitClient = createGitClient();
 const BRANCH_NAME = `chore/update-dependencies-${Date.now()}`;
-const PULL_REQUEST_TITLE = `chore(deps): daily update 'template.json'`;
-const REPOSITORY = 'create-contentful-app';
-const OWNER = 'contentful';
 
 (async function main() {
   const diffSummary = await gitClient.diffSummary();

--- a/scripts/dependency-check/merge-pull-request.js
+++ b/scripts/dependency-check/merge-pull-request.js
@@ -1,0 +1,54 @@
+const {
+  PULL_REQUEST_TITLE,
+  OWNER,
+  REPOSITORY,
+  createGitClient,
+  createGithubClient,
+} = require('./utils');
+
+async function main() {
+  const githubClient = createGithubClient();
+
+  const { data: pullRequests } = await githubClient.pulls.list({
+    owner: OWNER,
+    repo: REPOSITORY,
+    state: 'open',
+  });
+
+  const latestPullRequest = pullRequests
+    .filter((pullRequest) => pullRequest.title === PULL_REQUEST_TITLE)
+    .sort((a, b) => b.number - a.number)[0];
+
+  if (!latestPullRequest) {
+    return;
+  }
+
+  const {
+    data: { check_runs: checkRuns },
+  } = await githubClient.checks.listForRef({
+    owner: OWNER,
+    repo: REPOSITORY,
+    ref: latestPullRequest.head.sha,
+    filter: 'latest',
+  });
+
+  const allCheckRunsSuccessful = checkRuns.every(
+    ({ status, conclusion }) => status === 'completed' && conclusion === 'success'
+  );
+
+  if (!allCheckRunsSuccessful) {
+    return;
+  }
+
+  await githubClient.pulls.merge({
+    owner: OWNER,
+    repo: REPOSITORY,
+    pull_number: latestPullRequest.number,
+    merge_method: 'squash',
+  });
+
+  const gitClient = createGitClient();
+  await gitClient.pull('origin', 'master');
+}
+
+main();

--- a/scripts/dependency-check/utils.js
+++ b/scripts/dependency-check/utils.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs');
 
 const { Octokit } = require('@octokit/rest');
-const simpleGit = require('simple-git');
+const simpleGit = require('simple-git').default;
 
 const PULL_REQUEST_TITLE = `chore(deps): daily update 'template.json'`;
 

--- a/scripts/dependency-check/utils.js
+++ b/scripts/dependency-check/utils.js
@@ -1,6 +1,14 @@
 const path = require('path');
 const fs = require('fs');
 
+const { Octokit } = require('@octokit/rest');
+const simpleGit = require('simple-git');
+
+const PULL_REQUEST_TITLE = `chore(deps): daily update 'template.json'`;
+
+const OWNER = 'contentful';
+const REPOSITORY = 'create-contentful-app';
+
 const ROOT_PATH = path.resolve(__dirname, '..', '..');
 const SANDBOX_PATH = path.resolve(ROOT_PATH, 'dependency-check');
 const TEMPLATE_PATH = path.join(ROOT_PATH, 'template.json');
@@ -74,6 +82,16 @@ const validateAndRead = filePath => {
   }
 };
 
+function createGithubClient() {
+  return new Octokit({
+    auth: process.env.GITHUB_ACCESS_TOKEN
+  });
+}
+
+function createGitClient() {
+  return simpleGit(ROOT_PATH);
+}
+
 module.exports = {
   printError,
   printErrorAndExit,
@@ -82,9 +100,14 @@ module.exports = {
   printSuccess,
   validateAndRequire,
   validateAndRead,
+  PULL_REQUEST_TITLE,
+  OWNER,
+  REPOSITORY,
   ROOT_PATH,
   SANDBOX_PATH,
   OUTDATED_PATH,
   TEMPLATE_PATH,
-  TEST_REPORT_PATH
+  TEST_REPORT_PATH,
+  createGithubClient,
+  createGitClient
 };


### PR DESCRIPTION
### 1. Adds `dependencies` label to the dep-check PRs

### 2. Automatically merges dep-check PRs before creating a new PR.

Unfortunately, it is currently not possible to enable the GitHub auto-merge feature via the API (yet). So, we need to do this manually for now. The new script fetches all open PRs, filters them to get the latest dep-check PR, verifies that all checks were successful, squashes that PR and then fetches the latest `master` to the local git. Fetching the latest `master` ensures that the new PR does not contain the same updates as the already merged PR.

It might make sense to run this in a separate job as the final pull might not include the previously merged PR.