### PR TITLE
chore: fix typo & add ts-check

### DIFF
--- a/scripts/dependency-check/create-manifest-from-template
+++ b/scripts/dependency-check/create-manifest-from-template
@@ -1,5 +1,7 @@
 #! /usr/bin/env node
 
+// @ts-check
+
 const path = require('path')
 const fs = require('fs');
 const { printErrorAndExit, printInfo, SANDBOX_PATH, TEMPLATE_PATH, printHeader, printSuccess, validateAndRequire } = require('./utils');

--- a/scripts/dependency-check/create-pull-request
+++ b/scripts/dependency-check/create-pull-request
@@ -1,7 +1,8 @@
 #! /bin/usr/env node
+// @ts-check
 
 const { Octokit } = require('@octokit/rest');
-const simpleGit = require('simple-git');
+const simpleGit = require('simple-git').default;
 
 const {
   TEMPLATE_PATH,
@@ -15,7 +16,7 @@ const {
 const getCompatibilityBadge = (report) => {
   const testLine = report.split('\n').find(i => i.startsWith('Tests:'));
 
-  const [_, passed = 0, total = 0] = /(\d) passed, (\d) total/.exec(testLine) || [];
+  const [_, passed = '0', total = '0'] = /(\d) passed, (\d) total/.exec(testLine) || [];
   const compatibilityScore = (Number.parseInt(passed) * 100) / Number.parseInt(total);
 
   const compatibilityColor = compatibilityScore === 100
@@ -90,7 +91,7 @@ const OWNER = 'contentful';
       await githubClient.issues.createComment({
         owner: OWNER,
         repo: REPOSITORY,
-        pull_number: pullRequest.number,
+        issue_number: pullRequest.number,
         body: `Closed in favor of #${newPullRequest.number}`
       });
 

--- a/scripts/dependency-check/create-template-from-outdated
+++ b/scripts/dependency-check/create-template-from-outdated
@@ -1,5 +1,7 @@
 #! /usr/bin/env node
 
+// @ts-check
+
 const fs = require('fs')
 const {validateAndRequire, TEMPLATE_PATH, OUTDATED_PATH, printHeader, printInfo, printErrorAndExit, printSuccess} = require('./utils')
 

--- a/scripts/dependency-check/utils.js
+++ b/scripts/dependency-check/utils.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const path = require('path');
 const fs = require('fs');
 
@@ -86,5 +88,5 @@ module.exports = {
   SANDBOX_PATH,
   OUTDATED_PATH,
   TEMPLATE_PATH,
-  TEST_REPORT_PATH
+  TEST_REPORT_PATH,
 };


### PR DESCRIPTION
The parameter is called `issue_number` as we are adding a comment on an issue. 🙄 

To avoid these issues, I added `// @ts-check` to all dep-check scripts to enable typescript.