### PR TITLE
feat: [EXT-2597] use relative paths for build output

### DIFF
--- a/template.json
+++ b/template.json
@@ -19,6 +19,7 @@
     },
     "scripts": {
       "start": "cross-env BROWSER=none react-scripts start"
-    }
+    },
+    "homepage": "."
   }
 }


### PR DESCRIPTION
### **Purpose**

Adding the `"homepage": "."` field to the `package.json` template. 
It will ensure that the build files are refered with relative and not absolute links. 

The documentation will be updated when this is merged with: 
