### PR TITLE
Feat: scripts activate bundle by default

### DIFF
--- a/packages/@contentful--app-scripts/README.md
+++ b/packages/@contentful--app-scripts/README.md
@@ -81,7 +81,7 @@ It only runs in interactive mode.
 Allows you to upload a build directory and create a new AppBundle that is bound to an [AppDefinition](https://www.contentful.com/developers/docs/extensibility/app-framework/app-definition/).
 It runs in interactive or non-interactive mode
 
-**Note:** The command will automatically activate the bundle. To skip the activation you can either select it in the interactive mode or pass the `--skip-activation` argument and then manually [activate](#activate-an-appBundle) it
+**Note:** The command will automatically activate the bundle. To skip the activation you can pass the `--skip-activation` argument in interactive and non-interactive mode and then manually [activate](#activate-an-appBundle) it
 
 #### Interactive mode:
 

--- a/packages/@contentful--app-scripts/README.md
+++ b/packages/@contentful--app-scripts/README.md
@@ -81,7 +81,7 @@ It only runs in interactive mode.
 Allows you to upload a build directory and create a new AppBundle that is bound to an [AppDefinition](https://www.contentful.com/developers/docs/extensibility/app-framework/app-definition/).
 It runs in interactive or non-interactive mode
 
-**Note:** To make the app serve the bundle you need to [activate](#activate-an-appBundle) it
+**Note:** The command will automatically activate the bundle. To skip the activation you can either select it in the interactive mode or pass the `--skip-activation` argument and then manually [activate](#activate-an-appBundle) it
 
 #### Interactive mode:
 
@@ -95,7 +95,7 @@ In the interactive mode, the CLI will ask for all required options
 
 #### Non-interactive mode:
 
-When passing the `--ci` argument adding all variables as arguments is required
+When passing the `--ci` argument the command will fail when the required variables are not set as arguments.
 
 > **Example**
 >
@@ -111,10 +111,11 @@ When passing the `--ci` argument adding all variables as arguments is required
 
 | Argument                 | Description                                                                                                                                    |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--bundle-dir`           | The directory of your build folder (e.g.: `./build`)                                                                                            |
+| `--bundle-dir`           | The directory of your build folder (e.g.: `./build`)                                                                                           |
 | `--organization-id`      | The ID of your organisation                                                                                                                    |
 | `--definition-id`        | The ID of the app to which to add the bundle                                                                                                   |
 | `--token`                | A personal [access token](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/personal-access-tokens)     |
+| `--skip-activation`      | (optional) Boolean flag to skip the automatic activation of the `AppBundle`                                                                    |
 
 **Note:** You can also pass all arguments in interactive mode to skip being asked for it.
 

--- a/packages/@contentful--app-scripts/bin/app-scripts
+++ b/packages/@contentful--app-scripts/bin/app-scripts
@@ -31,6 +31,7 @@ async function runCommand(command, options) {
     .option('--definition-id [defId]', 'The id of your apps definition')
     .option('--token [accessToken]', 'Your content management access token')
     .option('--comment [comment]', 'Optional comment for the created bundle')
+    .option('--skip-activation', 'A Boolean flag to skip automatic activation')
     .action(async (options) => {
       await runCommand(upload, options);
     })

--- a/packages/@contentful--app-scripts/lib/upload/build-upload-settings.js
+++ b/packages/@contentful--app-scripts/lib/upload/build-upload-settings.js
@@ -19,14 +19,6 @@ async function buildAppUploadSettings(options) {
       default: '',
     });
   }
-  if (!options.skipActivation) {
-    prompts.push({
-      name: 'skipActivation',
-      message: `Skip automatic activation of the bundle:`,
-      type: 'confirm',
-      default: false,
-    });
-  }
 
   const appUploadSettings = await inquirer.prompt(prompts);
 
@@ -34,7 +26,7 @@ async function buildAppUploadSettings(options) {
   // Add app-config & dialog automatically
   return {
     bundleDirectory: options.bundleDir,
-    skipActivation: options.skipActivation,
+    skipActivation: !!options.skipActivation,
     comment: options.comment,
     ...appUploadSettings,
     ...appInfo,

--- a/packages/@contentful--app-scripts/lib/upload/build-upload-settings.js
+++ b/packages/@contentful--app-scripts/lib/upload/build-upload-settings.js
@@ -19,6 +19,14 @@ async function buildAppUploadSettings(options) {
       default: '',
     });
   }
+  if (!options.skipActivation) {
+    prompts.push({
+      name: 'skipActivation',
+      message: `Skip automatic activation of the bundle:`,
+      type: 'confirm',
+      default: false,
+    });
+  }
 
   const appUploadSettings = await inquirer.prompt(prompts);
 
@@ -26,6 +34,7 @@ async function buildAppUploadSettings(options) {
   // Add app-config & dialog automatically
   return {
     bundleDirectory: options.bundleDir,
+    skipActivation: options.skipActivation,
     comment: options.comment,
     ...appUploadSettings,
     ...appInfo,

--- a/packages/@contentful--app-scripts/lib/upload/create-app-bundle.js
+++ b/packages/@contentful--app-scripts/lib/upload/create-app-bundle.js
@@ -6,7 +6,6 @@ const { createClient } = require('contentful-management');
 const { createAppUpload } = require('./create-app-upload');
 
 async function createAppBundleFromUpload(settings, appUploadId) {
-  console.log(settings.definition);
   const clientSpinner = ora('Verifying your upload...').start();
   const client = createClient({ accessToken: settings.accessToken });
   const organization = await client.getOrganization(settings.organization.value);
@@ -56,7 +55,7 @@ async function createAppBundleFromSettings(settings) {
 
   Bundle Id: ${chalk.yellow(appBundle.sys.id)}
   `);
-  console.log(settings);
+
   if (settings.skipActivation) {
     console.log(`
   ${chalk.green(`NEXT STEPS:`)}

--- a/packages/@contentful--app-scripts/lib/upload/create-app-bundle.js
+++ b/packages/@contentful--app-scripts/lib/upload/create-app-bundle.js
@@ -56,7 +56,9 @@ async function createAppBundleFromSettings(settings) {
 
   Bundle Id: ${chalk.yellow(appBundle.sys.id)}
   `);
-  console.log(`
+  console.log(settings);
+  if (settings.skipActivation) {
+    console.log(`
   ${chalk.green(`NEXT STEPS:`)}
 
     ${chalk.bold('You can activate this app bundle in your apps settings:')}
@@ -68,6 +70,9 @@ async function createAppBundleFromSettings(settings) {
       ${chalk.underline('npx @contentful/app-scripts activate')}
 
   `);
+  }
+
+  return appBundle;
 }
 
 module.exports = {

--- a/packages/@contentful--app-scripts/lib/upload/get-upload-settings-args.js
+++ b/packages/@contentful--app-scripts/lib/upload/get-upload-settings-args.js
@@ -19,6 +19,7 @@ async function getUploadSettingsArgs(options) {
     return {
       ...appInfo,
       bundleDirectory: options.bundleDir,
+      skipActivation: options.skipActivation,
       comment: options.comment,
     };
   } catch (err) {

--- a/packages/@contentful--app-scripts/lib/upload/index.js
+++ b/packages/@contentful--app-scripts/lib/upload/index.js
@@ -1,15 +1,24 @@
+const { activateBundle } = require('../activate/activate-bundle');
 const { getUploadSettingsArgs } = require('./get-upload-settings-args');
 const { createAppBundleFromSettings } = require('./create-app-bundle');
 
 const { buildAppUploadSettings } = require('./build-upload-settings');
 
+async function uploadAndActivate(settings) {
+  const bundle = await createAppBundleFromSettings(settings);
+  console.log(settings);
+  if (!settings.skipActivation) {
+    await activateBundle({ ...settings, bundleId: bundle.sys.id });
+  }
+}
+
 module.exports = {
   async interactive(options) {
     const settings = await buildAppUploadSettings(options);
-    await createAppBundleFromSettings(settings);
+    await uploadAndActivate(settings);
   },
   async nonInteractive(options) {
     const settings = await getUploadSettingsArgs(options);
-    await createAppBundleFromSettings(settings);
+    await uploadAndActivate(settings);
   },
 };

--- a/packages/@contentful--app-scripts/lib/upload/index.js
+++ b/packages/@contentful--app-scripts/lib/upload/index.js
@@ -6,7 +6,6 @@ const { buildAppUploadSettings } = require('./build-upload-settings');
 
 async function uploadAndActivate(settings) {
   const bundle = await createAppBundleFromSettings(settings);
-  console.log(settings);
   if (!settings.skipActivation) {
     await activateBundle({ ...settings, bundleId: bundle.sys.id });
   }


### PR DESCRIPTION
Activating the upload automatically and add the option `--skip-activation` in non-interactive mode and also adds a prompt to skip activation in interactive mode. 

The documentation was also changed according to the automatic activation.