### PR TITLE
fix: always use current version for template

### DIFF
--- a/packages/@contentful--create-contentful-app/lib/index.js
+++ b/packages/@contentful--create-contentful-app/lib/index.js
@@ -7,6 +7,7 @@ const spawn = require('cross-spawn');
 const path = require('path');
 const tildify = require('tildify');
 const { createAppDefinition } = require('@contentful/app-scripts');
+const { version } = require('../package.json');
 
 const command = process.argv[2];
 const appFolder = process.argv[3];
@@ -42,7 +43,7 @@ function initProject() {
 
     const initCommand = 'node';
     const createReactApp = require.resolve('create-react-app');
-    const templatePkg = '@contentful/cra-template-create-contentful-app';
+    const templatePkg = `@contentful/cra-template-create-contentful-app@${version}`;
 
     const args = [createReactApp, appFolder, '--template', templatePkg, '--use-npm'];
 


### PR DESCRIPTION
Currently, in the CCA script, the template package was hardcoded without a specific version. 

Which leads to, when run as the canary version to not pick up the canary version of the template package. 

This adds the version to the template package as well. All packages should be in sync, so the version of the script should always be the same version as the template.