### PR TITLE
fix: always have versions in sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "test": "lerna run test",
     "lint": "lerna run lint",
     "link": "lerna link",
-    "version": "lerna version --no-private --conventional-commits --create-release github --yes --exact --force-publsih",
-    "publish": "lerna publish from-git --yes --no-verify-access --exact --force-publsih",
+    "version": "lerna version --no-private --conventional-commits --create-release github --yes --exact --force-publish",
+    "publish": "lerna publish from-git --yes --no-verify-access --exact --force-publish",
     "pre-commit": "lerna run pre-commit",
     "commit-msg": "lerna run commit-msg"
   },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "test": "lerna run test",
     "lint": "lerna run lint",
     "link": "lerna link",
-    "version": "lerna version --no-private --conventional-commits --create-release github --yes --exact",
-    "publish": "lerna publish from-git --yes --no-verify-access --exact",
+    "version": "lerna version --no-private --conventional-commits --create-release github --yes --exact --force-publsih",
+    "publish": "lerna publish from-git --yes --no-verify-access --exact --force-publsih",
     "pre-commit": "lerna run pre-commit",
     "commit-msg": "lerna run commit-msg"
   },


### PR DESCRIPTION
We expect all versions of the packages to be in sync, which means publishing a change in one package will publish a new version for all packages. 

By default, lerna will always only create a new version for the package that has been changed.

[The option `--force-publish`](https://github.com/lerna/lerna/tree/main/commands/version#--force-publish) will skip the diffing and will create a new version for all packages, if changed or not. 
This will make sure all package versions are in sync. 

Closes #403 