### PR TITLE
fix: set default location for activating app bundle [EXT-2712]

### DIFF
--- a/packages/contentful--app-scripts/lib/activate/activate-bundle.js
+++ b/packages/contentful--app-scripts/lib/activate/activate-bundle.js
@@ -6,6 +6,7 @@ const { createClient } = require('contentful-management');
 async function activateBundle({ accessToken, organization, definition, bundleId }) {
   const activationSpinner = ora('Activating your bundle').start();
   const plainClient = createClient({ accessToken }, { type: 'plain' });
+  const defaultLocations = [{location: 'dialog'}];
 
   const currentDefinition = await plainClient.appDefinition.get({
     appDefinitionId: definition.value,
@@ -19,6 +20,9 @@ async function activateBundle({ accessToken, organization, definition, bundleId 
       type: 'Link',
     },
   };
+  if (!currentDefinition.locations.length) {
+    currentDefinition.locations = defaultLocations;
+  }
   delete currentDefinition.src;
 
   try {

--- a/packages/contentful--app-scripts/lib/activate/activate-bundle.test.js
+++ b/packages/contentful--app-scripts/lib/activate/activate-bundle.test.js
@@ -23,6 +23,7 @@ describe('activate-bundle', () => {
   const definitionMock = {
     src: 'src',
     bundle: undefined,
+    locations: []
   };
 
   beforeEach(() => {
@@ -46,9 +47,10 @@ describe('activate-bundle', () => {
     }));
   });
 
-  it('updates definition with bundle and sets src to undefined', async () => {
+  it('updates definition with bundle, sets default location, and sets src to undefined', async () => {
     await activateBundle(mockedSettings);
     assert.strictEqual(definitionMock.bundle.sys.id, mockedSettings.bundleId);
+    assert.strictEqual(definitionMock.locations.length, 1);
     assert.strictEqual(definitionMock.src, undefined);
     assert.strictEqual(updateStub.called, true);
     assert(console.log.calledWith(match(/Your app bundle was activated/)));


### PR DESCRIPTION
To activate an app bundle, you need to have at least 1 location present. This sets at least one location (i.e: 'dialog' as it's a default location)