### PR TITLE
feat: [] adds `open-settings` command to app-scripts

### DIFF
--- a/packages/contentful--app-scripts/README.md
+++ b/packages/contentful--app-scripts/README.md
@@ -167,7 +167,7 @@ It opens the settings in the contentful web app so that you can use the UI to ch
 > **Example**
 >
 > ```shell
-> $ npx --no-install @contentful/app-scripts open --definition-id some-definition-id
+> $ npx --no-install @contentful/app-scripts open-settings --definition-id some-definition-id
 > ```
 
 You can also execute this command without the argument if the environment variable (`CONTENTFUL_APP_DEF_ID`) has been set. 
@@ -175,5 +175,5 @@ You can also execute this command without the argument if the environment variab
 > **Example**
 >
 > ```shell
-> $ CONTENTFUL_APP_DEF_ID=some-definition-id npx --no-install @contentful/app-scripts open
+> $ CONTENTFUL_APP_DEF_ID=some-definition-id npx --no-install @contentful/app-scripts open-settings
 > ```

--- a/packages/contentful--app-scripts/README.md
+++ b/packages/contentful--app-scripts/README.md
@@ -159,3 +159,21 @@ When passing the `--ci` argument adding all variables as arguments is required
 | `--token`                | A personal [access token](https://www.contentful.com/developers/docs/references/content-management-api/#/reference/personal-access-tokens)     |
 
 **Note:** You can also pass all arguments in interactive mode to skip being asked for it. 
+
+### Open Settings of an AppDefinition
+
+It opens the settings in the contentful web app so that you can use the UI to change the settings of an [AppDefinition](https://www.contentful.com/developers/docs/extensibility/app-framework/app-definition/). 
+
+> **Example**
+>
+> ```shell
+> $ npx --no-install @contentful/app-scripts open --definition-id some-definition-id
+> ```
+
+You can also execute this command without the argument if the environment variable (`CONTENTFUL_APP_DEF_ID`) has been set. 
+
+> **Example**
+>
+> ```shell
+> $ CONTENTFUL_APP_DEF_ID=some-definition-id npx --no-install @contentful/app-scripts open
+> ```

--- a/packages/contentful--app-scripts/bin/app-scripts
+++ b/packages/contentful--app-scripts/bin/app-scripts
@@ -52,7 +52,7 @@ async function runCommand(command, options) {
     .description('Opens the app editor for a given AppDefinition')
     .option('--definition-id  [defId]', 'The id of your apps definition')
     .action(async (options) => {
-      await open.run(options)
+      await runCommand(open, options);
     })
 
   await program.parseAsync(process.argv);

--- a/packages/contentful--app-scripts/bin/app-scripts
+++ b/packages/contentful--app-scripts/bin/app-scripts
@@ -48,7 +48,7 @@ async function runCommand(command, options) {
     })
 
   program
-    .command('open')
+    .command('open-settings')
     .description('Opens the app editor for a given AppDefinition')
     .option('--definition-id  [defId]', 'The id of your apps definition')
     .action(async (options) => {

--- a/packages/contentful--app-scripts/bin/app-scripts
+++ b/packages/contentful--app-scripts/bin/app-scripts
@@ -3,7 +3,7 @@
 const { program } = require('commander');
 const { version } = require('../package.json');
 
-const {createAppDefinition, upload, activate} = require('../')
+const {createAppDefinition, upload, activate, open} = require('../')
 
 
 async function runCommand(command, options) {
@@ -45,6 +45,14 @@ async function runCommand(command, options) {
     .option('--token [accessToken]', 'Your content management access token')
     .action(async (options) => {
       await runCommand(activate, options);
+    })
+
+  program
+    .command('open')
+    .description('Opens the app editor for a given AppDefinition')
+    .option('--definition-id  [defId]', 'The id of your apps definition')
+    .action(async (options) => {
+      await open.run(options)
     })
 
   await program.parseAsync(process.argv);

--- a/packages/contentful--app-scripts/lib/index.js
+++ b/packages/contentful--app-scripts/lib/index.js
@@ -1,9 +1,11 @@
 const createAppDefinition = require('./create-app-definition');
 const upload = require('./upload');
 const activate = require('./activate');
+const open = require('./open');
 
 module.exports = {
   createAppDefinition,
   upload,
   activate,
+  open,
 };

--- a/packages/contentful--app-scripts/lib/open/index.js
+++ b/packages/contentful--app-scripts/lib/open/index.js
@@ -1,26 +1,7 @@
-const open = require('open');
-const chalk = require('chalk');
-const { APP_DEF_ENV_KEY } = require('../../utils/constants');
-
-const REDIRECT_URL = 'https://app.contentful.com/deeplink?link=app-definition';
+const { openSettings } = require('./open-settings');
 
 module.exports = {
   async run(options) {
-    let definitionId;
-    if (options.definitionId) {
-      definitionId = options.definitionId;
-    } else if (process.env[APP_DEF_ENV_KEY]) {
-      definitionId = process.env[APP_DEF_ENV_KEY];
-    } else {
-      console.log(`
-        ${chalk.red('Error:')} There was no app-definition defined.
-
-        Please add it with ${chalk.cyan('--definition-id=<app-definition-id>')}
-        or set the environment variable ${chalk.cyan(`${APP_DEF_ENV_KEY} = <app-definition-id>`)}
-      `);
-      throw new Error('No app-definition-id');
-    }
-
-    open(`${REDIRECT_URL}&id=${definitionId}`);
+    openSettings(options);
   },
 };

--- a/packages/contentful--app-scripts/lib/open/index.js
+++ b/packages/contentful--app-scripts/lib/open/index.js
@@ -1,7 +1,10 @@
 const { openSettings } = require('./open-settings');
 
 module.exports = {
-  async run(options) {
+  interactive(options) {
     openSettings(options);
+  },
+  nonInteractive() {
+    throw new Error(`"open-settings" is not available in non-interactive mode`);
   },
 };

--- a/packages/contentful--app-scripts/lib/open/index.js
+++ b/packages/contentful--app-scripts/lib/open/index.js
@@ -1,0 +1,26 @@
+const open = require('open');
+const chalk = require('chalk');
+const { APP_DEF_ENV_KEY } = require('../../utils/constants');
+
+const REDIRECT_URL = 'https://app.contentful.com/deeplink?link=app-definition';
+
+module.exports = {
+  async run(options) {
+    let definitionId;
+    if (options.definitionId) {
+      definitionId = options.definitionId;
+    } else if (process.env[APP_DEF_ENV_KEY]) {
+      definitionId = process.env[APP_DEF_ENV_KEY];
+    } else {
+      console.log(`
+        ${chalk.red('Error:')} There was no app-definition defined.
+
+        Please add it with ${chalk.cyan('--definition-id=<app-definition-id>')}
+        or set the environment variable ${chalk.cyan(`${APP_DEF_ENV_KEY} = <app-definition-id>`)}
+      `);
+      throw new Error('No app-definition-id');
+    }
+
+    open(`${REDIRECT_URL}&id=${definitionId}`);
+  },
+};

--- a/packages/contentful--app-scripts/lib/open/open-settings.js
+++ b/packages/contentful--app-scripts/lib/open/open-settings.js
@@ -35,7 +35,13 @@ async function openSettings(options) {
     throw new Error('No app-definition-id');
   }
 
-  open(`${REDIRECT_URL}&id=${definitionId}`);
+  try {
+    open(`${REDIRECT_URL}&id=${definitionId}`);
+  } catch (err) {
+    console.log(`${chalk.red('Error:')} Failed to open browser`);
+    console.log(err.message);
+    throw err;
+  }
 }
 
 module.exports = {

--- a/packages/contentful--app-scripts/lib/open/open-settings.js
+++ b/packages/contentful--app-scripts/lib/open/open-settings.js
@@ -1,0 +1,29 @@
+const open = require('open');
+const chalk = require('chalk');
+const { APP_DEF_ENV_KEY } = require('../../utils/constants');
+
+const REDIRECT_URL = 'https://app.contentful.com/deeplink?link=app-definition';
+
+async function openSettings(options) {
+  let definitionId;
+  if (options.definitionId) {
+    definitionId = options.definitionId;
+  } else if (process.env[APP_DEF_ENV_KEY]) {
+    definitionId = process.env[APP_DEF_ENV_KEY];
+  } else {
+    console.log(`
+        ${chalk.red('Error:')} There was no app-definition defined.
+
+        Please add it with ${chalk.cyan('--definition-id=<app-definition-id>')}
+        or set the environment variable ${chalk.cyan(`${APP_DEF_ENV_KEY} = <app-definition-id>`)}
+      `);
+    throw new Error('No app-definition-id');
+  }
+
+  open(`${REDIRECT_URL}&id=${definitionId}`);
+}
+
+module.exports = {
+  openSettings,
+  REDIRECT_URL,
+};

--- a/packages/contentful--app-scripts/lib/open/open-settings.js
+++ b/packages/contentful--app-scripts/lib/open/open-settings.js
@@ -1,5 +1,6 @@
 const open = require('open');
 const chalk = require('chalk');
+const inquirer = require('inquirer');
 const { APP_DEF_ENV_KEY } = require('../../utils/constants');
 
 const REDIRECT_URL = 'https://app.contentful.com/deeplink?link=app-definition';
@@ -11,6 +12,16 @@ async function openSettings(options) {
   } else if (process.env[APP_DEF_ENV_KEY]) {
     definitionId = process.env[APP_DEF_ENV_KEY];
   } else {
+    const prompts = await inquirer.prompt([
+      {
+        name: 'definitionId',
+        message: `The id of the app:`,
+      },
+    ]);
+    definitionId = prompts.definitionId;
+  }
+
+  if (!definitionId) {
     console.log(`
         ${chalk.red('Error:')} There was no app-definition defined.
 

--- a/packages/contentful--app-scripts/lib/open/open-settings.js
+++ b/packages/contentful--app-scripts/lib/open/open-settings.js
@@ -21,6 +21,10 @@ async function openSettings(options) {
     definitionId = prompts.definitionId;
   }
 
+  console.log(definitionId, 'DEFID');
+  console.log(options, 'options');
+  console.log(process.env[APP_DEF_ENV_KEY], 'process.env[APP_DEF_ENV_KEY]');
+
   if (!definitionId) {
     console.log(`
         ${chalk.red('Error:')} There was no app-definition defined.

--- a/packages/contentful--app-scripts/lib/open/open-settings.test.js
+++ b/packages/contentful--app-scripts/lib/open/open-settings.test.js
@@ -7,8 +7,9 @@ const { REDIRECT_URL } = require('./open-settings');
 const TEST_DEF_ID = 'test-def-id';
 
 describe('openSettings', () => {
-  let subject, openMock;
+  let subject, openMock, inquirerMock;
   beforeEach(() => {
+    delete process.env[APP_DEF_ENV_KEY];
     stub(console, 'log');
   });
 
@@ -19,21 +20,21 @@ describe('openSettings', () => {
 
   beforeEach(() => {
     openMock = stub();
+    inquirerMock = stub();
     ({ openSettings: subject } = proxyquire('./open-settings', {
       open: openMock,
+      inquirer: { prompt: inquirerMock },
     }));
   });
 
-  it('works with env variable set', () => {
-    process.env[APP_DEF_ENV_KEY] = TEST_DEF_ID;
+  it('works with option passed', () => {
     subject({ definitionId: TEST_DEF_ID });
     assert(openMock.calledWith(`${REDIRECT_URL}&id=${TEST_DEF_ID}`));
   });
 
-  it('throws error when no definition is provided and open is not called', () => {
+  it('shows prompt when no definition is provided', () => {
     subject({});
-    assert(console.log.calledWith(match(/There was no app-definition defined/)));
-    assert.strictEqual(openMock.called, false);
+    assert.strictEqual(inquirerMock.called, true);
   });
 
   it('works with env variable set', () => {

--- a/packages/contentful--app-scripts/lib/open/open-settings.test.js
+++ b/packages/contentful--app-scripts/lib/open/open-settings.test.js
@@ -1,0 +1,44 @@
+const { stub, match } = require('sinon');
+const assert = require('assert');
+const { APP_DEF_ENV_KEY } = require('../../utils/constants');
+const proxyquire = require('proxyquire');
+const { REDIRECT_URL } = require('./open-settings');
+
+const TEST_DEF_ID = 'test-def-id';
+
+describe('openSettings', () => {
+  let subject, openMock;
+  beforeEach(() => {
+    stub(console, 'log');
+  });
+
+  afterEach(() => {
+    console.log.restore();
+    delete process.env[APP_DEF_ENV_KEY];
+  });
+
+  beforeEach(() => {
+    openMock = stub();
+    ({ openSettings: subject } = proxyquire('./open-settings', {
+      open: openMock,
+    }));
+  });
+
+  it('works with env variable set', () => {
+    process.env[APP_DEF_ENV_KEY] = TEST_DEF_ID;
+    subject({ definitionId: TEST_DEF_ID });
+    assert(openMock.calledWith(`${REDIRECT_URL}&id=${TEST_DEF_ID}`));
+  });
+
+  it('throws error when no definition is provided and open is not called', () => {
+    subject({});
+    assert(console.log.calledWith(match(/There was no app-definition defined/)));
+    assert.strictEqual(openMock.called, false);
+  });
+
+  it('works with env variable set', () => {
+    process.env[APP_DEF_ENV_KEY] = TEST_DEF_ID;
+    subject({});
+    assert(openMock.calledWith(`${REDIRECT_URL}&id=${TEST_DEF_ID}`));
+  });
+});

--- a/packages/contentful--app-scripts/lib/open/open-settings.test.js
+++ b/packages/contentful--app-scripts/lib/open/open-settings.test.js
@@ -1,4 +1,4 @@
-const { stub, match } = require('sinon');
+const { stub } = require('sinon');
 const assert = require('assert');
 const { APP_DEF_ENV_KEY } = require('../../utils/constants');
 const proxyquire = require('proxyquire');


### PR DESCRIPTION
Adds a simple open command to app-scripts. 
The structure of the call is a bit different as there is no sense to have a interactive/non-interactive mode, as this command will only run in one place and never in a CI. 

So there is only one function executed. 