### PR TITLE
fix: [] add dev dependencies to manifest creation

### DIFF
--- a/scripts/dependency-check/create-manifest-from-template
+++ b/scripts/dependency-check/create-manifest-from-template
@@ -21,7 +21,8 @@ const manifest = {
   name: "test",
   version: "0.0.1",
   private: true,
-  dependencies: template.package.dependencies
+  dependencies: template.package.dependencies,
+  devDependencies: template.package.devDependencies
 }
 
 try {


### PR DESCRIPTION
With `app-scripts` being part of the `devDependencies` the outdated check should also include the `devDependencies`