### PR TITLE
fix: [] incorrect path for dependency check

### DIFF
--- a/scripts/dependency-check/utils.js
+++ b/scripts/dependency-check/utils.js
@@ -12,7 +12,7 @@ const OWNER = 'contentful';
 const REPOSITORY = 'create-contentful-app';
 
 const ROOT_PATH = path.resolve(__dirname, '..', '..');
-const SANDBOX_PATH = path.resolve(ROOT_PATH, 'scripts', 'dependency-check');
+const SANDBOX_PATH = path.resolve(ROOT_PATH, 'dependency-check');
 const TEMPLATE_PATH = path.join(
   ROOT_PATH,
   'packages',


### PR DESCRIPTION
It seems like this path was mistakenly changed in a different PR, and we didn't notice as the dependency check script is only run on a timer.