### PR TITLE
chore: run npm install before checking outdated deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,10 @@ jobs:
           name: Create Package JSON
           command: node ./scripts/dependency-check/create-manifest-from-template
       - run:
+          name: Install packages
+          working_directory: ./dependency-check
+          command: npm install
+      - run:
           name: Check Outdated
           working_directory: ./dependency-check
           command: (npm outdated --json || true) > ./outdated.json


### PR DESCRIPTION
If you run `npm outdated` before `npm install`, only `dependencies` are displayed as outdated. Only if you run `npm install` also `devDependencies` are listed as outdated.
I didn't find any documentation or a cli flag for this, so I added `npm install` to the CI when updating the `template.json`.

In our case `@contentful/app-scripts` is a few versions behind.