### PR TITLE
chore: merge template.json PR with neutral GH check

### DIFF
--- a/scripts/dependency-check/merge-pull-request.js
+++ b/scripts/dependency-check/merge-pull-request.js
@@ -33,7 +33,8 @@ async function main() {
   });
 
   const allCheckRunsSuccessful = checkRuns.every(
-    ({ status, conclusion }) => status === 'completed' && conclusion === 'success'
+    ({ status, conclusion }) =>
+      status === 'completed' && ['success', 'skipped', 'neutral'].includes(conclusion)
   );
 
   if (!allCheckRunsSuccessful) {


### PR DESCRIPTION
The existing logic only merged the `template.json` PRs when all checks were successful. With the new GH action to auto merge dependabot PRs, one check is always `skipped`, because the conditions to run that check do not apply.

With this PR, the template.json PR is also merged when the conclusion is `skipped` or `neutral`.

