### PR TITLE
fix(tests): ignore typecheck for test which breaks dev-build

### DIFF
--- a/packages/contentful--cra-template-create-contentful-app/template/src/components/Field.spec.tsx
+++ b/packages/contentful--cra-template-create-contentful-app/template/src/components/Field.spec.tsx
@@ -4,6 +4,8 @@ import { render } from '@testing-library/react';
 
 describe('Field component', () => {
   it('Component text exists', () => {
+    // @ts-ignore This field component should ideally have an sdk and
+    // cma property. 
     const { getByText } = render(<Field />);
 
     expect(getByText('Hello Entry Field Component')).toBeInTheDocument();

--- a/packages/contentful--cra-template-create-contentful-app/template/src/components/Field.spec.tsx
+++ b/packages/contentful--cra-template-create-contentful-app/template/src/components/Field.spec.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import Field from './Field';
 import { render } from '@testing-library/react';
+import { mockCma, mockSdk } from '../../test/mocks';
 
 describe('Field component', () => {
   it('Component text exists', () => {
-    // @ts-ignore This field component should ideally have an sdk and
-    // cma property. 
-    const { getByText } = render(<Field />);
+    const { getByText } = render(<Field cma={mockCma} sdk={mockSdk} />);
 
     expect(getByText('Hello Entry Field Component')).toBeInTheDocument();
   });


### PR DESCRIPTION
Adding mock for `Fields.spec.ts` as it currently breaks when running `npm start` breaks due to an enforced type check.

![image](https://user-images.githubusercontent.com/43542437/146910823-f9f81637-b437-48ff-84dd-1ba8ff927aae.png)
