### PR TITLE
chore: remove `git add` from lint-staged

### DIFF
--- a/packages/contentful--app-scripts/package.json
+++ b/packages/contentful--app-scripts/package.json
@@ -15,10 +15,9 @@
   },
   "main": "lib/index.js",
   "lint-staged": {
-    "*.{js}": [
+    "*.js": [
       "eslint --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "bin": {

--- a/packages/contentful--cra-template-create-contentful-app/package.json
+++ b/packages/contentful--cra-template-create-contentful-app/package.json
@@ -37,12 +37,10 @@
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ],
     "*.css": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   }
 }

--- a/packages/contentful--create-contentful-app/package.json
+++ b/packages/contentful--create-contentful-app/package.json
@@ -17,8 +17,7 @@
   "lint-staged": {
     "*.js": [
       "eslint --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "bin": {

--- a/packages/create-contentful-app/package.json
+++ b/packages/create-contentful-app/package.json
@@ -17,8 +17,7 @@
   "lint-staged": {
     "*.js": [
       "eslint --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "bin": {


### PR DESCRIPTION
Changelog of `lint-staged` v10:
> From v10.0.0 onwards any new modifications to originally staged files will be automatically added to the commit. If your task previously contained a git add step, please remove this.


Also `*.{js}` causes errors and should be `*.js`