### PR TITLE
fix: change `create-definition` to `create-app-definition`

### DIFF
--- a/packages/contentful--app-scripts/lib/create-app-definition/create-app-definition.js
+++ b/packages/contentful--app-scripts/lib/create-app-definition/create-app-definition.js
@@ -6,10 +6,7 @@ const { isString, isPlainObject, has } = require('lodash');
 
 const { throwValidationException, selectFromList } = require('../utils');
 const { cacheEnvVars } = require('../../utils/cache-credential');
-const {
-  ORG_ID_ENV_KEY,
-  APP_DEF_ENV_KEY,
-} = require('../../utils/constants');
+const { ORG_ID_ENV_KEY, APP_DEF_ENV_KEY } = require('../../utils/constants');
 
 async function fetchOrganizations(client) {
   try {
@@ -64,7 +61,11 @@ async function createAppDefinition(accessToken, appDefinitionSettings = { locati
   const client = createClient({ accessToken });
   const organizations = await fetchOrganizations(client);
 
-  const selectedOrg = await selectFromList(organizations, 'Select an organization for your app:', ORG_ID_ENV_KEY);
+  const selectedOrg = await selectFromList(
+    organizations,
+    'Select an organization for your app:',
+    ORG_ID_ENV_KEY
+  );
   const organizationId = selectedOrg.value;
 
   const appName = appDefinitionSettings.name || path.basename(process.cwd());
@@ -89,7 +90,7 @@ async function createAppDefinition(accessToken, appDefinitionSettings = { locati
     const organization = await client.getOrganization(organizationId);
     const createdAppDefinition = await organization.createAppDefinition(body);
     await cacheEnvVars({
-      [APP_DEF_ENV_KEY]: createdAppDefinition.sys.id
+      [APP_DEF_ENV_KEY]: createdAppDefinition.sys.id,
     });
 
     console.log(`
@@ -111,7 +112,7 @@ async function createAppDefinition(accessToken, appDefinitionSettings = { locati
   } catch (err) {
     console.log(`
   Something went wrong while creating the app definition.
-  Run ${chalk.cyan('`npx @contentful/create-contentful-app create-definition`')} to try again.
+  Run ${chalk.cyan('`npx @contentful/app-scripts create-app-definition`')} to try again.
 
   ${err.message}
     `);

--- a/packages/contentful--create-contentful-app/src/index.ts
+++ b/packages/contentful--create-contentful-app/src/index.ts
@@ -56,7 +56,7 @@ async function validateAppName(appName: string): Promise<string> {
         'create-contentful-app'
       )}.\nTo create a new app definition first run ${code(
         'npx create-contentful-app'
-      )} and then ${code('npm run create-definition')} within the new folder.`
+      )} and then ${code('npm run create-app-definition')} within the new folder.`
     );
   }
 


### PR DESCRIPTION
* Update the log message in App Scripts
* Update the log message when using the removed `create-definition` command in CCA (see https://github.com/contentful/apps/pull/788)