### PR TITLE
chore: remove --force-publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bootstrap": "lerna bootstrap",
     "test": "lerna run test",
     "lint": "lerna run lint",
-    "version": "lerna version --no-private --conventional-commits --create-release github --yes --exact --force-publish",
+    "version": "lerna version --no-private --conventional-commits --create-release github --yes --exact",
     "publish": "lerna publish from-git --yes --no-verify-access",
     "publish:canary": "lerna publish from-git --canary --yes --no-verify-access",
     "pre-commit": "lerna run pre-commit",


### PR DESCRIPTION
The packages are currently still all updated at once. Removing `--force-publish`

https://github.com/lerna/lerna/blob/main/commands/version/README.md#--force-publish

> This will skip the lerna changed check for changed packages and forces a package that didn't have a git diff change to be updated.

