### PR TITLE
chore: use regular `lerna bootstrap`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/contentful/create-contentful-app.git"
   },
   "scripts": {
-    "bootstrap": "lerna link && lerna exec npm install",
+    "bootstrap": "lerna bootstrap",
     "test": "lerna run test",
     "lint": "lerna run lint",
     "build": "lerna run build",


### PR DESCRIPTION
With the current "workaround" we have the issue that the `package-lock.json` files get updated after running `npm install`.
This PR changes the bootstrap logic back to the lerna default as I didn't notice anything being broken with it. 🤞 

This should fix the issue in `master` where we have uncommited changes: https://app.circleci.com/pipelines/github/contentful/create-contentful-app/5083/workflows/8604e124-3148-408c-917b-157d14995040/jobs/17700?invite=true#step-107-13

This issue is originally caused by `lerna` not updating `lockfileVersion` 2 package-lock files correctly. An alternative solution could be patching `lerna` with this PR https://github.com/lerna/lerna/pull/2914, but that feels like too much effort if this simple change can fix things. 🤞 