### PR TITLE
fix: `useCMA()` return value

### DIFF
--- a/packages/contentful--react-apps-toolkit/src/useCMA.ts
+++ b/packages/contentful--react-apps-toolkit/src/useCMA.ts
@@ -6,7 +6,7 @@ import { useSDK } from './useSDK';
  * React hook returning a CMA plain client instance.
  * Must be used in the `SDKProvider` component. Will throw error, if called outside of `SDKProvider`.
  */
-export function useCMA(): PlainClientAPI | undefined {
+export function useCMA(): PlainClientAPI {
   const sdk = useSDK();
 
   const cma = useMemo(() => {


### PR DESCRIPTION
The hook will never return `undefined`