### PR TITLE
feat: return updated value when setting a field value via `useFieldValue` [EXT-3654]

### DIFF
--- a/packages/contentful--react-apps-toolkit/src/useFieldValue.spec.ts
+++ b/packages/contentful--react-apps-toolkit/src/useFieldValue.spec.ts
@@ -1,4 +1,4 @@
-import { PageExtensionSDK } from '@contentful/app-sdk';
+import { PageExtensionSDK, SerializedJSONValue } from '@contentful/app-sdk';
 import { act, renderHook, RenderResult } from '@testing-library/react-hooks';
 import { useFieldValue, UseFieldValueReturnValue } from './useFieldValue';
 import { useSDK } from './useSDK';
@@ -36,7 +36,12 @@ const useSDKMock = useSDK as jest.MockedFn<typeof useSDK>;
 beforeEach(() => {
   jest.resetAllMocks();
   mockSDK.entry.fields.fieldId.onValueChanged.mockImplementation(() => () => {});
+  mockSDK.entry.fields.fieldId.setValue.mockImplementation(() => Promise.resolve('return value'));
+
   mockSDK.entry.fields.otherFieldId.onValueChanged.mockImplementation(() => () => {});
+  mockSDK.entry.fields.otherFieldId.setValue.mockImplementation(() =>
+    Promise.resolve('other return value')
+  );
 });
 
 describe('useFieldValue', () => {
@@ -96,7 +101,9 @@ describe('useFieldValue', () => {
     });
 
     it('updates value', async () => {
-      await act(() => result.current[1]('new value'));
+      await act(async () => {
+        await result.current[1]('new value');
+      });
       expect(result.current[0]).toBe('new value');
       expect(mockSDK.entry.fields['fieldId'].setValue).toHaveBeenCalledWith(
         'new value',
@@ -110,6 +117,15 @@ describe('useFieldValue', () => {
 
       act(() => calls[0][1]('new value'));
       expect(result.current[0]).toBe('new value');
+    });
+
+    it('returns the updated value', async () => {
+      let returnedValue: SerializedJSONValue | undefined;
+      await act(async () => {
+        returnedValue = await result.current[1]('new value');
+      });
+
+      expect(returnedValue).toBe('return value');
     });
   });
 
@@ -127,7 +143,9 @@ describe('useFieldValue', () => {
     });
 
     it('updates value', async () => {
-      await act(() => result.current[1]('new value'));
+      await act(async () => {
+        await result.current[1]('new value');
+      });
       expect(result.current[0]).toBe('new value');
       expect(mockSDK.entry.fields['otherFieldId'].setValue).toHaveBeenCalledWith(
         'new value',
@@ -158,7 +176,9 @@ describe('useFieldValue', () => {
     });
 
     it('updates value', async () => {
-      await act(() => result.current[1]('new value'));
+      await act(async () => {
+        await result.current[1]('new value');
+      });
       expect(result.current[0]).toBe('new value');
       expect(mockSDK.entry.fields['fieldId'].setValue).toHaveBeenCalledWith('new value', 'locale');
     });

--- a/packages/contentful--react-apps-toolkit/src/useFieldValue.tsx
+++ b/packages/contentful--react-apps-toolkit/src/useFieldValue.tsx
@@ -1,10 +1,10 @@
-import { EntryFieldAPI, KnownSDK } from '@contentful/app-sdk';
+import { EntryFieldAPI, KnownSDK, SerializedJSONValue } from '@contentful/app-sdk';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSDK } from './useSDK';
 
 export type UseFieldValueReturnValue<Value = unknown> = [
   value: Value | undefined,
-  setValue: (newValue: Value | undefined) => Promise<void>
+  setValue: (newValue: Value | undefined) => Promise<SerializedJSONValue | undefined>
 ];
 
 /**
@@ -34,7 +34,7 @@ export function useFieldValue<Value = unknown>(
   const updateValue = useCallback(
     async (newValue: Value | undefined) => {
       setValue(newValue);
-      await entryFieldApi.setValue(newValue, localeWithDefault);
+      return await entryFieldApi.setValue(newValue, localeWithDefault);
     },
     [entryFieldApi, localeWithDefault]
   );


### PR DESCRIPTION
Sometimes the value changes when calling `setValue`. With this change, the value is returned when calling `setValue` of `useFieldValue`.