### PR TITLE
feat: React Apps Toolkit v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11220,7 +11220,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -11257,6 +11256,8 @@
       "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
       "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
@@ -11270,6 +11271,8 @@
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
       "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "object-assign": "^4.1.1",
         "react-is": "^17.0.2",
@@ -13972,7 +13975,7 @@
     },
     "packages/contentful--react-apps-toolkit": {
       "name": "@contentful/react-apps-toolkit",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@contentful/app-sdk": "^4.0.0",
@@ -13985,7 +13988,7 @@
         "@types/react": "^17.0.39",
         "jest": "^27.5.0",
         "react": "^17.0.2",
-        "react-test-renderer": "17.0.2",
+        "react-dom": "17.0.2",
         "ts-jest": "^27.1.3",
         "typescript": "^4.5.5"
       },
@@ -14462,7 +14465,7 @@
         "contentful-management": ">=7.30.0",
         "jest": "^27.5.0",
         "react": "^17.0.2",
-        "react-test-renderer": "17.0.2",
+        "react-dom": "17.0.2",
         "ts-jest": "^27.1.3",
         "typescript": "^4.5.5"
       }
@@ -22971,7 +22974,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -22998,6 +23000,8 @@
       "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
       "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
@@ -23008,6 +23012,8 @@
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.2.tgz",
       "integrity": "sha512-yaQ9cB89c17PUb0x6UfWRs7kQCorVdHlutU1boVPEsB8IDZH6n9tHxMacc3y0JoXOJUsZb/t/Mb8FUWMKaM7iQ==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "object-assign": "^4.1.1",
         "react-is": "^17.0.2",

--- a/packages/contentful--react-apps-toolkit/README.md
+++ b/packages/contentful--react-apps-toolkit/README.md
@@ -1,7 +1,3 @@
-# In development
-
-This library is still in development and should not be used in production.
-
 # React Toolkit for Contentful Apps
 
 React Hooks for the App Framework offer a simple way to bring frequently needed functionality into your react based [Contentful apps](/developers/docs/extensibility/app-framework/).

--- a/packages/contentful--react-apps-toolkit/package.json
+++ b/packages/contentful--react-apps-toolkit/package.json
@@ -40,7 +40,7 @@
     "@types/react": "^17.0.39",
     "jest": "^27.5.0",
     "react": "^17.0.2",
-    "react-test-renderer": "17.0.2",
+    "react-dom": "17.0.2",
     "ts-jest": "^27.1.3",
     "typescript": "^4.5.5"
   },

--- a/packages/contentful--react-apps-toolkit/src/SDKProvider.tsx
+++ b/packages/contentful--react-apps-toolkit/src/SDKProvider.tsx
@@ -1,7 +1,7 @@
-import React, { FC, ReactElement, useRef } from 'react';
 import { init, KnownSDK } from '@contentful/app-sdk';
+import { createContext, FC, ReactElement, useEffect, useState } from 'react';
 
-export const SDKContext = React.createContext<{ sdk: KnownSDK | null }>({ sdk: null });
+export const SDKContext = createContext<{ sdk: KnownSDK | null }>({ sdk: null });
 
 interface SDKProviderProps {
   loading?: ReactElement;
@@ -14,9 +14,9 @@ const DELAY_TIMEOUT = 4 * 1000;
  * @param props.loading an optional loading element that gets rendered while initializing the app
  */
 export const SDKProvider: FC<SDKProviderProps> = (props) => {
-  const [sdk, setSDK] = React.useState<KnownSDK | undefined>();
+  const [sdk, setSDK] = useState<KnownSDK | undefined>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const timeout = window.setTimeout(() => {
       console.warn(
         "Your app is taking longer than expected to initialize. If you think this is an error with Contentful's App SDK, let us know: https://github.com/contentful/ui-extensions-sdk/issues"


### PR DESCRIPTION
BREAKING CHANGE: React Apps Toolkit v1

**React Hooks for building apps faster**

React is the most popular framework when it comes to writing Contentful apps and with the new React Apps Toolkit, we provide multiple new React hooks that abstract the most common use cases. That way, you have to write less boilerplate code and can focus on the core functionality of your Contentful app.  Combined with Contentful’s open source Forma 36 design library it allows developers to seamlessly integrate into Contentful so that you can build editorial apps faster with less manual work. To learn more about the new React Apps Toolkit, check out the [package on npm](https://www.npmjs.com/package/@contentful/react-apps-toolkit).

**Usage:**

```tsx
ReactDOM.render(
  // wrap the app with the SDK Provider, so the new hooks can be used
  <SDKProvider>
    <App />
  </SDKProvider>,
  document.getElementById(‘root’)
);

function App() {
  // returns an instance of the App SDK
  const sdk = useSDK();
  
  // returns an initialized plain CMA client
  const cma = useCMA();

  // returns the current state of a field and an update method
  const [value, setValue] = useFieldValue();

  // …
}
```