### PR TITLE
chore: ignore package-lock.json changes

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -5,8 +5,14 @@
   "command": {
     "publish": {
       "ignoreChanges": [
+        ".*",
         "*.md",
-        "package-lock.json"
+        "*.spec.*",
+        "*.test.*",
+        "jest.config.js",
+        "package-lock.json",
+        "tsconfig.json",
+        "docs"
       ],
       "message": "chore(release): release [skip ci]"
     }

--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,8 @@
   "command": {
     "publish": {
       "ignoreChanges": [
-        "*.md"
+        "*.md",
+        "package-lock.json"
       ],
       "message": "chore(release): release [skip ci]"
     }


### PR DESCRIPTION
This should reduce the number of releases.