### PR TITLE
chore: reenable CI releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,13 +120,13 @@ workflows:
           requires:
             - lint-and-test-16
 
-      # - release:
-      #     filters:
-      #       branches:
-      #         only: master
-      #     requires:
-      #       - test-built-app-14
-      #       - test-built-app-16
+      - release:
+          filters:
+            branches:
+              only: master
+          requires:
+            - test-built-app-14
+            - test-built-app-16
 
       - release-canary:
           filters:


### PR DESCRIPTION
This reverts commit 35e0aec2b862fd7a2fe08f0ef85c45f9f93a8019.

React Apps Toolkit won't release :) 

```
create-contentful-app git:(master) ./node_modules/.bin/lerna changed
lerna notice cli v4.0.0
lerna info versioning independent
lerna info Looking for changed packages since @contentful/react-apps-toolkit@1.0.1
lerna info ignoring diff in paths matching [
lerna info ignoring diff in paths matching   '.*',
lerna info ignoring diff in paths matching   '*.md',
lerna info ignoring diff in paths matching   '*.spec.*',
lerna info ignoring diff in paths matching   '*.test.*',
lerna info ignoring diff in paths matching   'jest.config.js',
lerna info ignoring diff in paths matching   'package-lock.json',
lerna info ignoring diff in paths matching   'tsconfig.json',
lerna info ignoring diff in paths matching   'docs'
lerna info ignoring diff in paths matching ]
@contentful/app-scripts
@contentful/create-contentful-app
create-contentful-app
lerna success found 3 packages ready to publish
```