### PR TITLE
fix: handle undefined error

### DIFF
--- a/packages/contentful--create-contentful-app/src/index.ts
+++ b/packages/contentful--create-contentful-app/src/index.ts
@@ -104,7 +104,7 @@ async function initProject(appName: string, options: CLIOptions) {
 
     successMessage(fullAppFolder);
   } catch (err) {
-    error(`Failed to create ${appName}`, err instanceof Error ? err : String(err));
+    error(`Failed to create ${appName}`, err);
     process.exit(1);
   }
 }

--- a/packages/contentful--create-contentful-app/src/logger.ts
+++ b/packages/contentful--create-contentful-app/src/logger.ts
@@ -4,15 +4,19 @@ export function warn(message: string): void {
   console.log(`${chalk.yellow('Warning:')} ${message}`);
 }
 
-export function error(message: string, error: string | Error): void {
-  if (error instanceof Error) {
-    console.log(`${chalk.red('Error:')} ${message}\n`);
+export function error(message: string, error: unknown): void {
+  console.log(`${chalk.red('Error:')} ${message}`);
+  if (error === undefined) {
+    return;
+  } else if (error instanceof Error) {
+    console.log();
     console.log(error);
   } else {
-    console.log(`${chalk.red('Error:')} ${message}
-
-  ${error.startsWith('Error: ') ? error.substring(7) : error}
-`);
+    const strigifiedError = String(error);
+    console.log();
+    console.log(
+      `${strigifiedError.startsWith('Error: ') ? strigifiedError.substring(7) : strigifiedError}`
+    );
   }
 }
 


### PR DESCRIPTION
`err` is of type `unknown` and can therefore also be `undefined`. This e.g. happens when the installation fails. In that case the error is already logged to the console and we reject the promise (https://github.com/contentful/create-contentful-app/blob/6c1f8e278404d7705b2180c96be641fd628e6c35/packages/contentful--create-contentful-app/src/utils.ts#L16). As we stringify `err`, this causes the following output:

![image](https://user-images.githubusercontent.com/4947671/165496264-7ecd3d73-751d-4cdc-adf0-34b5fb2b89be.png)

With this change, we handle the different types of errors within the `error` function and filter out `undefined`