### PR TITLE
docs: use absolute screenshot url

### DIFF
--- a/packages/contentful--create-contentful-app/README.md
+++ b/packages/contentful--create-contentful-app/README.md
@@ -17,7 +17,7 @@ To start developing your first app, run:
 npx create-contentful-app my-first-app
 ```
 
-![Screenshot of `npx create-contentful-app my-app`](./docs/screenshot.png)
+![Screenshot of `npx create-contentful-app my-app`](https://raw.githubusercontent.com/contentful/create-contentful-app/master/packages/contentful--create-contentful-app/docs/screenshot.png)
 
 ## Bootstrap
 

--- a/packages/create-contentful-app/README.md
+++ b/packages/create-contentful-app/README.md
@@ -17,7 +17,7 @@ To start developing your first app, run:
 npx create-contentful-app my-first-app
 ```
 
-![Screenshot of `npx create-contentful-app my-app`](./docs/screenshot.png)
+![Screenshot of `npx create-contentful-app my-app`](https://raw.githubusercontent.com/contentful/create-contentful-app/master/packages/create-contentful-app/docs/screenshot.png)
 
 ## Bootstrap
 


### PR DESCRIPTION
The screenshot is currently not visible on npm as the image url is relative

-> https://www.npmjs.com/package/create-contentful-app