### PR TITLE
chore: fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,16 +8,6 @@ environment: &base-env
   NPM_CONFIG_PROGRESS: 'false'
   NPM_CONFIG_LOGLEVEL: warn
 
-install-deps: &install-deps
-  run:
-    name: Install Dependencies
-    command: npm ci && npm run bootstrap
-
-build: &build
-  run:
-    name: Build
-    command: npm run build
-
 executors:
   node-container-14:
     docker:
@@ -35,11 +25,23 @@ executors:
         environment: *base-env
 
 commands:
+  install-deps:
+    steps:
+      - run:
+          name: Install Dependencies
+          command: npm ci && npm run bootstrap
+
+  build:
+    steps:
+      - run:
+          name: Build
+          command: npm run build
+
   lint-and-test:
     steps:
       - checkout
-      - *install-deps
-      - *build
+      - install-deps
+      - build
       - run:
           name: Run Linter
           command: npm run lint
@@ -50,8 +52,8 @@ commands:
   test-built-app:
     steps:
       - checkout
-      - *install-deps
-      - *build
+      - install-deps
+      - build
       - run:
           name: Run Tests
           command: |
@@ -67,12 +69,12 @@ commands:
     steps:
       - checkout
       - vault/get-secrets:
-          template-preset: "semantic-release"
+          template-preset: 'semantic-release'
       - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
       - run: git config --global user.email "${GIT_AUTHOR_EMAIL}"
       - run: git config --global user.name "${GIT_AUTHOR_NAME}"
-      - *install-deps
-      - *build
+      - install-deps
+      - build
 
 jobs:
   release:
@@ -172,4 +174,3 @@ workflows:
             - test-built-app-14
             - test-built-app-16
             - test-built-app-18
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,13 +62,6 @@ commands:
             node "${FORMER_CWD}/packages/contentful--create-contentful-app/lib/index.js" --typescript test
             cd test
             npm t
-  build:
-    steps:
-      - checkout
-      - *install-deps
-      - run:
-          name: Run build
-          command: npm run build
 
   prepare-release:
     steps:
@@ -80,12 +73,6 @@ commands:
       - run: git config --global user.name "${GIT_AUTHOR_NAME}"
       - *install-deps
       - *build
-
-  nx_set_shas:
-    steps:
-      - nx/set-shas:
-          error-on-no-successful-workflow: true
-          main-branch-name: master
 
 jobs:
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,6 @@ jobs:
       - test-built-app
 
 workflows:
-  version: 2
-
   test:
     jobs:
       - lint-and-test-14:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,8 @@ commands:
       - vault/get-secrets:
           template-preset: "semantic-release"
       - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
-      - run: git config --global user.email "tech-accounts+gh+whydah-gally@contentful.com"
-      - run: git config --global user.name "whydah-gally"
+      - run: git config --global user.email "${GIT_AUTHOR_EMAIL}"
+      - run: git config --global user.name "${GIT_AUTHOR_NAME}"
       - *install-deps
       - *build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ commands:
       - vault/get-secrets:
           template-preset: 'semantic-release'
       - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc
+      - run: export GH_TOKEN=${GITHUB_TOKEN}
       - run: git config --global user.email "${GIT_AUTHOR_EMAIL}"
       - run: git config --global user.name "${GIT_AUTHOR_NAME}"
       - install-deps


### PR DESCRIPTION
We cannot use CircleCI user keys anymore for releases (and pushing to github), so we need to use the credentials exposed by vault (GITHUB_TOKEN, GIT_AUTHOR_EMAIL, GIT_AUTHOR_NAME).

I also did some minor refactor removing unused commands and deprecated properties