### PR TITLE
chore: ignore package.json

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -10,6 +10,7 @@
         "*.spec.*",
         "*.test.*",
         "jest.config.js",
+        "package.json",
         "package-lock.json",
         "tsconfig.json",
         "docs"


### PR DESCRIPTION
# Problem

Dependabot constantly updates the dependancies of the root and all packages. Each of these updates changes `package.json` and `package-lock.json` files. This makes lerna automatically trigger new releases. For `create-contentful-app` we are now in release 107 where only a dependency, but not the actual code changed.

# Goal

We do not want to spam npm with new versions. Us triggering a new version triggers dependabot of dependant packages/projects causing noise for our users. We only want to release a new version if something actually changed.

# Proposed solution

`package-lock.json` is already ignored for lerna. This PR also ignores `package.json`. That way, the changes made by dependabot do not trigger a new lerna release.

(I am not sure whether this is the perfect solution, but it's the best I could come up with and which works in a private project of mine)


# Caveats

- If we manually only change `package.json` or `package-lock.json` no new version will be released
- CCA and App Scripts does not always use the latest version of all dependencies. I still consider this to be safe because the code is run on developers machines and CI, never in production, so there is not really an attack surface.