### PR TITLE
allowNetworks argument added in app action manifest[EXT-4509]

### DIFF
--- a/packages/contentful--app-scripts/lib/utills.test.js
+++ b/packages/contentful--app-scripts/lib/utills.test.js
@@ -45,14 +45,9 @@ describe('removeProtocolFromUrl', () => {
     assert.strictEqual(result, 'example.com');
   });
 
-  it('returns undefined for an invalid URL', () => {
-    const result = removeProtocolFromUrl('not a url');
-    assert.strictEqual(result, undefined);
-  });
-
   it('returns valid ipv6 address', () => {
-    const result = removeProtocolFromUrl('2001:0db8:85a3:0000:0000:8a2e:0370:7334');
-    assert.strictEqual(result, '[2001:db8:85a3::8a2e:370:7334]');
+    const result = removeProtocolFromUrl('http://[2001:0db8:85a3:0000:0000:8a2e:0370]:7334');
+    assert.strictEqual(result, '[2001:0db8:85a3:0000:0000:8a2e:0370]:7334');
   });
 
   it('returns valid domain', () => {

--- a/packages/contentful--app-scripts/lib/utills.test.js
+++ b/packages/contentful--app-scripts/lib/utills.test.js
@@ -44,4 +44,19 @@ describe('removeProtocolFromUrl', () => {
     const result = removeProtocolFromUrl('not a url');
     assert.strictEqual(result, undefined);
   });
+
+  it('returns valid ipv6 address', () => {
+    const result = removeProtocolFromUrl('2001:0db8:85a3:0000:0000:8a2e:0370:7334');
+    assert.strictEqual(result, '[2001:db8:85a3::8a2e:370:7334]');
+  });
+
+  it('returns valid domain', () => {
+    const result = removeProtocolFromUrl('example.com');
+    assert.strictEqual(result, 'example.com');
+  });
+
+  it('returns valid domain with port', () => {
+    const result = removeProtocolFromUrl('example.com:40');
+    assert.strictEqual(result, 'example.com:40');
+  });
 });

--- a/packages/contentful--app-scripts/lib/utills.test.js
+++ b/packages/contentful--app-scripts/lib/utills.test.js
@@ -32,6 +32,11 @@ describe('isValidIpAddress', () => {
     const result = isValidIpAddress('not an ip address');
     assert.strictEqual(result, false);
   });
+
+  it('returns true for an valid ipv6 address with port', () => {
+    const result = isValidIpAddress('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443');
+    assert.strictEqual(result, true);
+  });
 });
 
 describe('removeProtocolFromUrl', () => {

--- a/packages/contentful--app-scripts/lib/utills.test.js
+++ b/packages/contentful--app-scripts/lib/utills.test.js
@@ -1,0 +1,47 @@
+const assert = require('assert');
+
+const { isValidIpAddress, removeProtocolFromUrl } = require('./utils');
+
+describe('isValidIpAddress', () => {
+  it('returns true for a valid IP address', () => {
+    const result = isValidIpAddress('192.168.0.1');
+    assert.strictEqual(result, true);
+  });
+
+  it('returns true for a valid domain', () => {
+    const result = isValidIpAddress('http://google.com');
+    assert.strictEqual(result, true);
+  });
+
+  it('returns true for a valid ipv6 address', () => {
+    const result = isValidIpAddress('2001:0db8:85a3:0000:0000:8a2e:0370:7334');
+    assert.strictEqual(result, true);
+  });
+
+  it('returns true for a valid domain with port', () => {
+    const result = isValidIpAddress('http://google.com:4000');
+    assert.strictEqual(result, true);
+  });
+
+  it('returns true for a valid IP address with port', () => {
+    const result = isValidIpAddress('192.168.0.1:2000');
+    assert.strictEqual(result, true);
+  });
+
+  it('returns false for an invalid IP address', () => {
+    const result = isValidIpAddress('not an ip address');
+    assert.strictEqual(result, false);
+  });
+});
+
+describe('removeProtocolFromUrl', () => {
+  it('returns the host of a URL without a protocol', () => {
+    const result = removeProtocolFromUrl('http://example.com');
+    assert.strictEqual(result, 'example.com');
+  });
+
+  it('returns undefined for an invalid URL', () => {
+    const result = removeProtocolFromUrl('not a url');
+    assert.strictEqual(result, undefined);
+  });
+});

--- a/packages/contentful--app-scripts/lib/utills.test.js
+++ b/packages/contentful--app-scripts/lib/utills.test.js
@@ -9,7 +9,7 @@ describe('isValidIpAddress', () => {
   });
 
   it('returns true for a valid domain', () => {
-    const result = isValidIpAddress('http://google.com');
+    const result = isValidIpAddress('google.com');
     assert.strictEqual(result, true);
   });
 
@@ -19,7 +19,7 @@ describe('isValidIpAddress', () => {
   });
 
   it('returns true for a valid domain with port', () => {
-    const result = isValidIpAddress('http://google.com:4000');
+    const result = isValidIpAddress('google.com:4000');
     assert.strictEqual(result, true);
   });
 

--- a/packages/contentful--app-scripts/lib/utills.test.js
+++ b/packages/contentful--app-scripts/lib/utills.test.js
@@ -1,62 +1,62 @@
 const assert = require('assert');
 
-const { isValidIpAddress, removeProtocolFromUrl } = require('./utils');
+const { isValidNetwork, stripProtocol } = require('./utils');
 
 describe('isValidIpAddress', () => {
   it('returns true for a valid IP address', () => {
-    const result = isValidIpAddress('192.168.0.1');
+    const result = isValidNetwork('192.168.0.1');
     assert.strictEqual(result, true);
   });
 
   it('returns true for a valid domain', () => {
-    const result = isValidIpAddress('google.com');
+    const result = isValidNetwork('google.com');
     assert.strictEqual(result, true);
   });
 
   it('returns true for a valid ipv6 address', () => {
-    const result = isValidIpAddress('2001:0db8:85a3:0000:0000:8a2e:0370:7334');
+    const result = isValidNetwork('2001:0db8:85a3:0000:0000:8a2e:0370:7334');
     assert.strictEqual(result, true);
   });
 
   it('returns true for a valid domain with port', () => {
-    const result = isValidIpAddress('google.com:4000');
+    const result = isValidNetwork('google.com:4000');
     assert.strictEqual(result, true);
   });
 
   it('returns true for a valid IP address with port', () => {
-    const result = isValidIpAddress('192.168.0.1:2000');
+    const result = isValidNetwork('192.168.0.1:2000');
     assert.strictEqual(result, true);
   });
 
   it('returns false for an invalid IP address', () => {
-    const result = isValidIpAddress('not an ip address');
+    const result = isValidNetwork('not an ip address');
     assert.strictEqual(result, false);
   });
 
   it('returns true for an valid ipv6 address with port', () => {
-    const result = isValidIpAddress('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443');
+    const result = isValidNetwork('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443');
     assert.strictEqual(result, true);
   });
 });
 
 describe('removeProtocolFromUrl', () => {
   it('returns the host of a URL without a protocol', () => {
-    const result = removeProtocolFromUrl('http://example.com');
+    const result = stripProtocol('http://example.com');
     assert.strictEqual(result, 'example.com');
   });
 
   it('returns valid ipv6 address', () => {
-    const result = removeProtocolFromUrl('http://[2001:0db8:85a3:0000:0000:8a2e:0370]:7334');
+    const result = stripProtocol('http://[2001:0db8:85a3:0000:0000:8a2e:0370]:7334');
     assert.strictEqual(result, '[2001:0db8:85a3:0000:0000:8a2e:0370]:7334');
   });
 
   it('returns valid domain', () => {
-    const result = removeProtocolFromUrl('example.com');
+    const result = stripProtocol('example.com');
     assert.strictEqual(result, 'example.com');
   });
 
   it('returns valid domain with port', () => {
-    const result = removeProtocolFromUrl('example.com:40');
+    const result = stripProtocol('example.com:40');
     assert.strictEqual(result, 'example.com:40');
   });
 });

--- a/packages/contentful--app-scripts/lib/utils.js
+++ b/packages/contentful--app-scripts/lib/utils.js
@@ -99,7 +99,9 @@ function getActionsManifest() {
     console.log('');
 
     const actions = manifest.actions.map((action) => {
-      const allowedNetworks = Array.isArray(action.allowedNetworks) ? action.allowedNetworks : [];
+      const allowedNetworks = Array.isArray(action.allowedNetworks)
+        ? [...action.allowedNetworks, 'api.contentful.com', 'upload.contentful.com', '127.0.0.1']
+        : ['api.contentful.com', 'upload.contentful.com', '127.0.0.1'];
 
       const validAllowedNetworks = allowedNetworks
         .map(removeProtocolFromUrl)
@@ -118,10 +120,7 @@ function getActionsManifest() {
       return {
         parameters: [],
         ...action,
-        allowedNetworks:
-          validAllowedNetworks.length > 0
-            ? validAllowedNetworks
-            : ['api.contentful.com', 'upload.contentful.com', '127.0.0.1'],
+        allowedNetworks: validAllowedNetworks,
       };
     });
 

--- a/packages/contentful--app-scripts/lib/utils.js
+++ b/packages/contentful--app-scripts/lib/utils.js
@@ -2,7 +2,6 @@ const fs = require('fs');
 const chalk = require('chalk');
 const inquirer = require('inquirer');
 const { cacheEnvVars } = require('../utils/cache-credential');
-const { URL } = require('url');
 
 const DEFAULT_MANIFEST_PATH = './contentful-app-manifest.json';
 
@@ -22,20 +21,13 @@ const isValidNetwork = (address) => {
 
 const removeProtocolFromUrl = (url) => {
   try {
-    const hasProtocol = /^https?:\/\//.test(url);
+    const protocolRemovedUrl = url.replace(/^https?:\/\//, '');
 
-    const isIPv6 = /^(\[[a-fA-F0-9:]+\])|(([a-fA-F0-9]{1,4}:){7}[a-fA-F0-9]{1,4})$/.test(url);
-
-    let prefixedUrl = isIPv6 ? (url.match(/^\[.+\]$/) ? url : `[${url}]`) : url;
-
-    if (!hasProtocol) {
-      prefixedUrl = `http://${prefixedUrl}`;
-    }
-
-    const { host } = new URL(prefixedUrl);
+    const host = protocolRemovedUrl.split('/')[0];
 
     return host;
   } catch (e) {
+    console.log(e);
     return;
   }
 };

--- a/packages/contentful--app-scripts/lib/utils.js
+++ b/packages/contentful--app-scripts/lib/utils.js
@@ -14,18 +14,32 @@ const throwValidationException = (subject, message, details) => {
   throw new TypeError(message);
 };
 
-const isValidIpAddress = (ipAddress) => {
-  const ipRegex = /^((?:[0-9]{1,3}\.){3}[0-9]{1,3}|(?:[a-z0-9-]+\.)+[a-z]{2,})(?::([0-9]{1,5}))?$/i;
-  return ipRegex.test(ipAddress);
+const isValidIpAddress = (address) => {
+  const addressRegex =
+    /^(?:(?:https?|ftp):\/\/)?(?:localhost|(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6}|(?:\d{1,3}\.){3}\d{1,3}|(\[(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\]|(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}))(?::\d{1,5})?$/;
+  return addressRegex.test(address);
 };
 
 const removeProtocolFromUrl = (url) => {
   try {
-    const prefixedUrl = /^(\d{1,3}\.){3}\d{1,3}(:\d{1,5})?$/.test(url) ? `http://${url}` : url;
+    const hasProtocol = /^https?:\/\//.test(url);
+
+    const isIPv6 = /^\[?[a-fA-F0-9:]+\]?$/.test(url);
+
+    let prefixedUrl = isIPv6 ? (url.match(/^\[.+\]$/) ? url : `[${url}]`) : url;
+
+    if (!hasProtocol) {
+      if (!isIPv6) {
+        prefixedUrl = `http://${prefixedUrl}`;
+      } else {
+        prefixedUrl = `http://${prefixedUrl}`;
+      }
+    }
+
     const { host } = new URL(prefixedUrl);
+
     return host;
   } catch (e) {
-    //swallow error here to throw more suitable error in getActionsManifest function
     return;
   }
 };
@@ -140,4 +154,6 @@ module.exports = {
   selectFromList,
   showCreationError,
   getActionsManifest,
+  isValidIpAddress,
+  removeProtocolFromUrl,
 };

--- a/packages/contentful--app-scripts/lib/utils.js
+++ b/packages/contentful--app-scripts/lib/utils.js
@@ -137,6 +137,6 @@ module.exports = {
   selectFromList,
   showCreationError,
   getActionsManifest,
-  isValidIpAddress: isValidNetwork,
-  removeProtocolFromUrl: stripProtocol,
+  isValidNetwork,
+  stripProtocol,
 };

--- a/packages/contentful--app-scripts/lib/utils.js
+++ b/packages/contentful--app-scripts/lib/utils.js
@@ -29,7 +29,7 @@ const removeProtocolFromUrl = (url) => {
     let prefixedUrl = isIPv6 ? (url.match(/^\[.+\]$/) ? url : `[${url}]`) : url;
 
     if (!hasProtocol) {
-      prefixedUrl = `http://${prefixedUrl}/`;
+      prefixedUrl = `http://${prefixedUrl}`;
     }
 
     const { host } = new URL(prefixedUrl);

--- a/packages/contentful--app-scripts/lib/utils.js
+++ b/packages/contentful--app-scripts/lib/utils.js
@@ -14,7 +14,7 @@ const throwValidationException = (subject, message, details) => {
   throw new TypeError(message);
 };
 
-const validateIpAddress = (ipAddress) => {
+const isValidIpAddress = (ipAddress) => {
   const ipRegex = /^((?:[0-9]{1,3}\.){3}[0-9]{1,3}|(?:[a-z0-9-]+\.)+[a-z]{2,})(?::([0-9]{1,5}))?$/i;
   return ipRegex.test(ipAddress);
 };
@@ -99,15 +99,13 @@ function getActionsManifest() {
     console.log('');
 
     const actions = manifest.actions.map((action) => {
-      const allowedNetworks = Array.isArray(action.allowedNetworks)
-        ? [...action.allowedNetworks, 'api.contentful.com', 'upload.contentful.com', '127.0.0.1']
-        : ['api.contentful.com', 'upload.contentful.com', '127.0.0.1'];
+      const allowedNetworks = Array.isArray(action.allowedNetworks) ? action.allowedNetworks : [];
 
-      const validAllowedNetworks = allowedNetworks
+      const hasInvalidNetworks = allowedNetworks
         .map(removeProtocolFromUrl)
-        .filter(validateIpAddress);
+        .some((netWork) => !isValidIpAddress(netWork));
 
-      if (validAllowedNetworks.length !== allowedNetworks.length) {
+      if (Array.isArray(hasInvalidNetworks) && hasInvalidNetworks.length > 0) {
         console.log(
           `${chalk.red(
             'Error:'
@@ -120,7 +118,7 @@ function getActionsManifest() {
       return {
         parameters: [],
         ...action,
-        allowedNetworks: validAllowedNetworks,
+        allowedNetworks: allowedNetworks,
       };
     });
 

--- a/packages/contentful--app-scripts/lib/utils.js
+++ b/packages/contentful--app-scripts/lib/utils.js
@@ -24,16 +24,12 @@ const removeProtocolFromUrl = (url) => {
   try {
     const hasProtocol = /^https?:\/\//.test(url);
 
-    const isIPv6 = /^\[?[a-fA-F0-9:]+\]?$/.test(url);
+    const isIPv6 = /^(\[[a-fA-F0-9:]+\])|(([a-fA-F0-9]{1,4}:){7}[a-fA-F0-9]{1,4})$/.test(url);
 
     let prefixedUrl = isIPv6 ? (url.match(/^\[.+\]$/) ? url : `[${url}]`) : url;
 
     if (!hasProtocol) {
-      if (!isIPv6) {
-        prefixedUrl = `http://${prefixedUrl}`;
-      } else {
-        prefixedUrl = `http://${prefixedUrl}`;
-      }
+      prefixedUrl = `http://${prefixedUrl}/`;
     }
 
     const { host } = new URL(prefixedUrl);

--- a/packages/contentful--app-scripts/lib/utils.js
+++ b/packages/contentful--app-scripts/lib/utils.js
@@ -128,7 +128,7 @@ function getActionsManifest() {
       return {
         parameters: [],
         ...action,
-        allowedNetworks: allowedNetworks,
+        allowedNetworks,
       };
     });
 

--- a/packages/contentful--app-scripts/lib/utils.js
+++ b/packages/contentful--app-scripts/lib/utils.js
@@ -121,7 +121,7 @@ function getActionsManifest() {
         allowedNetworks:
           validAllowedNetworks.length > 0
             ? validAllowedNetworks
-            : ['api.contentful.com', '127.0.0.1'],
+            : ['api.contentful.com', 'upload.contentful.com', '127.0.0.1'],
       };
     });
 

--- a/packages/contentful--app-scripts/lib/utils.js
+++ b/packages/contentful--app-scripts/lib/utils.js
@@ -20,8 +20,14 @@ const validateIpAddress = (ipAddress) => {
 };
 
 const removeProtocolFromUrl = (url) => {
-  const { hostname } = new URL(url);
-  return hostname;
+  try {
+    const prefixedUrl = /^(\d{1,3}\.){3}\d{1,3}(:\d{1,5})?$/.test(url) ? `http://${url}` : url;
+    const { host } = new URL(prefixedUrl);
+    return host;
+  } catch (e) {
+    //swallow error here to throw more suitable error in getActionsManifest function
+    return;
+  }
 };
 
 const showCreationError = (subject, message) => {

--- a/packages/contentful--app-scripts/lib/utils.js
+++ b/packages/contentful--app-scripts/lib/utils.js
@@ -14,7 +14,7 @@ const throwValidationException = (subject, message, details) => {
   throw new TypeError(message);
 };
 
-const isValidIpAddress = (address) => {
+const isValidNetwork = (address) => {
   const addressRegex =
     /^(?:(?:https?|ftp):\/\/)?(?:localhost|(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6}|(?:\d{1,3}\.){3}\d{1,3}|(\[(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\]|(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}))(?::\d{1,5})?$/;
   return addressRegex.test(address);
@@ -113,7 +113,7 @@ function getActionsManifest() {
 
       const hasInvalidNetworks = allowedNetworks
         .map(removeProtocolFromUrl)
-        .some((netWork) => !isValidIpAddress(netWork));
+        .some((netWork) => !isValidNetwork(netWork));
 
       if (hasInvalidNetworks) {
         console.log(
@@ -150,6 +150,6 @@ module.exports = {
   selectFromList,
   showCreationError,
   getActionsManifest,
-  isValidIpAddress,
+  isValidIpAddress: isValidNetwork,
   removeProtocolFromUrl,
 };

--- a/packages/contentful--app-scripts/lib/utils.js
+++ b/packages/contentful--app-scripts/lib/utils.js
@@ -115,7 +115,7 @@ function getActionsManifest() {
         .map(removeProtocolFromUrl)
         .some((netWork) => !isValidIpAddress(netWork));
 
-      if (Array.isArray(hasInvalidNetworks) && hasInvalidNetworks.length > 0) {
+      if (hasInvalidNetworks) {
         console.log(
           `${chalk.red(
             'Error:'
@@ -128,7 +128,7 @@ function getActionsManifest() {
       return {
         parameters: [],
         ...action,
-        allowedNetworks,
+        allowedNetworks: allowedNetworks.map(removeProtocolFromUrl),
       };
     });
 

--- a/packages/contentful--app-scripts/lib/utils.js
+++ b/packages/contentful--app-scripts/lib/utils.js
@@ -16,7 +16,7 @@ const throwValidationException = (subject, message, details) => {
 
 const isValidNetwork = (address) => {
   const addressRegex =
-    /^(?:(?:https?|ftp):\/\/)?(?:localhost|(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6}|(?:\d{1,3}\.){3}\d{1,3}|(\[(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\]|(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}))(?::\d{1,5})?$/;
+    /^(?:localhost|(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6}|(?:\d{1,3}\.){3}\d{1,3}|(\[(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\]|(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}))(?::\d{1,5})?$/;
   return addressRegex.test(address);
 };
 

--- a/packages/contentful--app-scripts/package.json
+++ b/packages/contentful--app-scripts/package.json
@@ -27,7 +27,7 @@
     "prettier": "prettier **/*.js --write --ignore-path .gitignore",
     "lint": "eslint ./lib",
     "lint:fix": "npm run lint -- --fix",
-    "test": "mocha ./lib/**/*.test.js ./lib/*.test.js ./utils/**/*.test.js",
+    "test": "mocha ./lib/*.test.js",
     "test:watch": "npm t -- --watch",
     "pre-commit": "lint-staged"
   },

--- a/packages/contentful--app-scripts/package.json
+++ b/packages/contentful--app-scripts/package.json
@@ -27,7 +27,7 @@
     "prettier": "prettier **/*.js --write --ignore-path .gitignore",
     "lint": "eslint ./lib",
     "lint:fix": "npm run lint -- --fix",
-    "test": "mocha ./lib/*.test.js",
+    "test": "mocha ./lib/**/*.test.js ./lib/*.test.js ./utils/**/*.test.js",
     "test:watch": "npm t -- --watch",
     "pre-commit": "lint-staged"
   },


### PR DESCRIPTION
Adding new endpoint property `allowNetworks` in the action manifest file.

User should provide the list of allowed networks in action manifest file.

By default the below networks will always have access
`api.contentful.com, upload.contentful.com, 127.0.0.1` 