### PR TITLE
fix: remove unnecessary params []

### DIFF
--- a/packages/contentful--app-scripts/lib/utils.js
+++ b/packages/contentful--app-scripts/lib/utils.js
@@ -116,7 +116,6 @@ function getActionsManifest() {
       const { entryFile: _, ...actionWithoutEntryFile } = action;
 
       return {
-        parameters: [],
         ...actionWithoutEntryFile,
         allowNetworks,
       };


### PR DESCRIPTION
Remove unnecessary params. This fails for uploading when the category !== 'Custom'