### PR TITLE
chore(useCMA): deprecate useCMA hook and encourage users to use sdk.cma

### DIFF
--- a/packages/contentful--react-apps-toolkit/src/useCMA.ts
+++ b/packages/contentful--react-apps-toolkit/src/useCMA.ts
@@ -13,10 +13,7 @@ type UseCMAReturnValue = (CMAClient extends never ? true : false) extends false
   ? CMAClient
   : PlainClientAPI;
 
-/**
- * React hook returning a CMA plain client instance.
- * Must be used in the `SDKProvider` component. Will throw error, if called outside of `SDKProvider`.
- */
+/** @deprecated Use `sdk.cma` instead */
 export function useCMA(): UseCMAReturnValue {
   const sdk = useSDK();
 


### PR DESCRIPTION
This is a sister PR for when [this PR](https://github.com/contentful/ui-extensions-sdk/pull/1536) gets merged into the AppSDK.

We no longer need a hook to allow the user to access the CMAClient. The AppSDK will now expose a `.cma` property that will give user access to an initialized plain client