### PR TITLE
chore: downgrade prettier to v2 due to incompatibility with lerna v6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       - dependency-name: "@types/node"
         versions:
           - ">=15.0.0"
+      - dependency-name: "prettier"
+        versions:
+          - ">=3.0.0"
     commit-message:
       prefix: fix
       prefix-development: chore

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "lint-staged": "14.0.0",
         "mocha": "10.2.0",
         "nx": "16.6.0",
-        "prettier": "3.0.2",
+        "prettier": "2.8.8",
         "proxyquire": "2.1.3",
         "sinon": "15.2.0",
         "typescript": "4.9.5"
@@ -10461,15 +10461,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
-      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
-        "prettier": "bin/prettier.cjs"
+        "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10.13.0"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -20485,9 +20485,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.2.tgz",
-      "integrity": "sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint-staged": "14.0.0",
     "mocha": "10.2.0",
     "nx": "16.6.0",
-    "prettier": "3.0.2",
+    "prettier": "2.8.8",
     "proxyquire": "2.1.3",
     "sinon": "15.2.0",
     "typescript": "4.9.5"


### PR DESCRIPTION
It seems that the recently released v3.x.x version of `prettier` is [not compatible with](https://github.com/lerna/lerna/issues/3765) the v6.x.x version of `lerna`. 
Due to the breaking changes in `lerna` v7 it seems easier to pin `prettier` on v2.x.x for now and [unblock the pipeline](https://app.circleci.com/pipelines/github/contentful/create-contentful-app/8469/workflows/496e2a08-8677-43e1-a70a-79828e29a1c3/jobs/32104).

