### PR TITLE
chore: upgrade to node lts (v18) [EXT-4812]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,19 +9,14 @@ environment: &base-env
   NPM_CONFIG_LOGLEVEL: warn
 
 executors:
-  node-container-14:
-    docker:
-      - image: cimg/node:14.15.0
-        environment: *base-env
-
-  node-container-16:
-    docker:
-      - image: cimg/node:16.14.0
-        environment: *base-env
-
   node-container-18:
     docker:
       - image: cimg/node:18.12.0
+        environment: *base-env
+
+  node-container-20:
+    docker:
+      - image: cimg/node:20.7
         environment: *base-env
 
 commands:
@@ -93,46 +88,36 @@ commands:
 
 jobs:
   release:
-    executor: node-container-16
+    executor: node-container-18
     steps:
       - prepare-release
       - run: npm run version
       - run: npm run publish
 
   release-canary:
-    executor: node-container-16
+    executor: node-container-18
     steps:
       - prepare-release
       - run: npm run version:canary
       - run: npm run publish:canary
-
-  lint-and-test-14:
-    executor: node-container-14
-    steps:
-      - lint-and-test
-
-  lint-and-test-16:
-    executor: node-container-16
-    steps:
-      - lint-and-test
 
   lint-and-test-18:
     executor: node-container-18
     steps:
       - lint-and-test
 
-  test-built-app-14:
-    executor: node-container-14
+  lint-and-test-20:
+    executor: node-container-20
     steps:
-      - test-built-app
-
-  test-built-app-16:
-    executor: node-container-16
-    steps:
-      - test-built-app
+      - lint-and-test
 
   test-built-app-18:
     executor: node-container-18
+    steps:
+      - test-built-app
+
+  test-built-app-20:
+    executor: node-container-20
     steps:
       - test-built-app
 
@@ -140,28 +125,15 @@ jobs:
     executor: node-container-18
     steps:
       - test-built-actions-delivery-functions
+  
+  test-built-app-20-actions-delivery-functions:
+    executor: node-container-20
+    steps:
+      - test-built-actions-delivery-functions
 
 workflows:
   test:
     jobs:
-      - lint-and-test-14:
-          context:
-            - vault
-      - test-built-app-14:
-          context:
-            - vault
-          requires:
-            - lint-and-test-14
-
-      - lint-and-test-16:
-          context:
-            - vault
-      - test-built-app-16:
-          context:
-            - vault
-          requires:
-            - lint-and-test-16
-
       - lint-and-test-18:
           context:
             - vault
@@ -173,7 +145,17 @@ workflows:
       - test-built-app-18-actions-delivery-functions:
           context:
             - vault
-
+      - lint-and-test-20:
+          context:
+            - vault
+      - test-built-app-20:
+          context:
+            - vault
+          requires:
+            - lint-and-test-20
+      - test-built-app-20-actions-delivery-functions:
+          context:
+            - vault
       - release:
           context:
             - vault
@@ -181,10 +163,10 @@ workflows:
             branches:
               only: master
           requires:
-            - test-built-app-14
-            - test-built-app-16
             - test-built-app-18
             - test-built-app-18-actions-delivery-functions
+            - test-built-app-20
+            - test-built-app-20-actions-delivery-functions
 
       - release-canary:
           context:
@@ -193,7 +175,7 @@ workflows:
             branches:
               only: canary
           requires:
-            - test-built-app-14
-            - test-built-app-16
             - test-built-app-18
             - test-built-app-18-actions-delivery-functions
+            - test-built-app-20
+            - test-built-app-20-actions-delivery-functions

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
         "proxyquire": "2.1.3",
         "sinon": "16.0.0",
         "typescript": "4.9.5"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "proxyquire": "2.1.3",
     "sinon": "16.0.0",
     "typescript": "4.9.5"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE
- deprecate v14 and v16 CI workflows & add v20
- specify v18 in `engines` in package.json