### PR TITLE
feat: assume ts for deliveryFunction if no option provided [MONET-1564]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
             PROJECT=test-$(date +%s)
             mkdir "/tmp/${PROJECT}"
             cd "/tmp/${PROJECT}"
-            node "${FORMER_CWD}/packages/contentful--create-contentful-app/lib/index.js" my-action-delivery-function --typescript --action --delivery-function
+            node "${FORMER_CWD}/packages/contentful--create-contentful-app/lib/index.js" my-action-delivery-function --action --delivery-function
             cd my-action-delivery-function
             npm run build
 
@@ -125,7 +125,7 @@ jobs:
     executor: node-container-18
     steps:
       - test-built-actions-delivery-functions
-  
+
   test-built-app-20-actions-delivery-functions:
     executor: node-container-20
     steps:

--- a/packages/contentful--create-contentful-app/src/getTemplateSource.ts
+++ b/packages/contentful--create-contentful-app/src/getTemplateSource.ts
@@ -92,7 +92,7 @@ async function makeContentfulExampleSource(options: CLIOptions): Promise<string>
     return selectTemplate(ContentfulExample.Typescript);
   }
 
-  if (options.deliveryFunction) {
+  if (options.deliveryFunction || options.action) {
     return selectTemplate(ContentfulExample.Typescript);
   }
 

--- a/packages/contentful--create-contentful-app/src/getTemplateSource.ts
+++ b/packages/contentful--create-contentful-app/src/getTemplateSource.ts
@@ -92,6 +92,10 @@ async function makeContentfulExampleSource(options: CLIOptions): Promise<string>
     return selectTemplate(ContentfulExample.Typescript);
   }
 
+  if (options.deliveryFunction) {
+    return selectTemplate(ContentfulExample.Typescript);
+  }
+
   return await promptExampleSelection();
 }
 

--- a/packages/contentful--create-contentful-app/src/includeAppAction.ts
+++ b/packages/contentful--create-contentful-app/src/includeAppAction.ts
@@ -12,13 +12,13 @@ const addBuildCommand = getAddBuildCommandFn({
   command: 'node build-actions.js',
 });
 
-export async function cloneAppAction(destination: string, templateIsTypescript: boolean) {
+export async function cloneAppAction(destination: string, templateIsJavascript: boolean) {
   try {
     console.log(highlight('---- Cloning hosted app action.'));
     // Clone the app actions template to the created directory under the folder 'actions'
     const templateSource = join(
       'contentful/apps/examples/hosted-app-action-templates',
-      templateIsTypescript ? 'typescript' : 'javascript',
+      templateIsJavascript ? 'javascript' : 'typescript',
     );
 
     const appActionDirectoryPath = resolve(`${destination}/actions`);

--- a/packages/contentful--create-contentful-app/src/includeDeliveryFunction.ts
+++ b/packages/contentful--create-contentful-app/src/includeDeliveryFunction.ts
@@ -11,13 +11,13 @@ const addBuildCommand = getAddBuildCommandFn({
   command: 'node build-delivery-functions.js',
 });
 
-export async function cloneDeliveryFunction(destination: string, templateIsTypescript: boolean) {
+export async function cloneDeliveryFunction(destination: string, templateIsJavascript: boolean) {
   try {
     console.log(highlight('---- Cloning hosted delivery function.'));
     // Clone the delivery function template to the created directory under the folder 'actions'
     const templateSource = join(
       'contentful/apps/examples/hosted-delivery-function-templates',
-      templateIsTypescript ? 'typescript' : 'javascript',
+      templateIsJavascript ? 'javascript' : 'typescript',
     );
 
     const deliveryFunctionDirectoryPath = resolve(`${destination}/delivery-functions`);

--- a/packages/contentful--create-contentful-app/src/index.ts
+++ b/packages/contentful--create-contentful-app/src/index.ts
@@ -114,7 +114,8 @@ async function initProject(appName: string, options: CLIOptions) {
       !normalizedOptions.example &&
       !normalizedOptions.source &&
       !normalizedOptions.javascript &&
-      !normalizedOptions.typescript;
+      !normalizedOptions.typescript &&
+      !normalizedOptions.deliveryFunction;
 
     const templateSource = await getTemplateSource(options);
 
@@ -135,7 +136,7 @@ async function initProject(appName: string, options: CLIOptions) {
       isContentfulTemplate(templateSource) &&
       normalizedOptions.deliveryFunction
     ) {
-      await cloneDeliveryFunction(fullAppFolder, !!normalizedOptions.typescript);
+      await cloneDeliveryFunction(fullAppFolder, !normalizedOptions.javascript);
     }
 
     updatePackageName(fullAppFolder);

--- a/packages/contentful--create-contentful-app/src/index.ts
+++ b/packages/contentful--create-contentful-app/src/index.ts
@@ -129,7 +129,7 @@ async function initProject(appName: string, options: CLIOptions) {
     await cloneTemplateIn(fullAppFolder, templateSource);
 
     if (!isInteractive && isContentfulTemplate(templateSource) && normalizedOptions.action) {
-      await cloneAppAction(fullAppFolder, !normalizedOptions.javascript);
+      await cloneAppAction(fullAppFolder, !!normalizedOptions.javascript);
     }
 
     if (
@@ -137,7 +137,7 @@ async function initProject(appName: string, options: CLIOptions) {
       isContentfulTemplate(templateSource) &&
       normalizedOptions.deliveryFunction
     ) {
-      await cloneDeliveryFunction(fullAppFolder, !normalizedOptions.javascript);
+      await cloneDeliveryFunction(fullAppFolder, !!normalizedOptions.javascript);
     }
 
     updatePackageName(fullAppFolder);

--- a/packages/contentful--create-contentful-app/src/index.ts
+++ b/packages/contentful--create-contentful-app/src/index.ts
@@ -115,7 +115,8 @@ async function initProject(appName: string, options: CLIOptions) {
       !normalizedOptions.source &&
       !normalizedOptions.javascript &&
       !normalizedOptions.typescript &&
-      !normalizedOptions.deliveryFunction;
+      !normalizedOptions.deliveryFunction &&
+      !normalizedOptions.action;
 
     const templateSource = await getTemplateSource(options);
 
@@ -128,7 +129,7 @@ async function initProject(appName: string, options: CLIOptions) {
     await cloneTemplateIn(fullAppFolder, templateSource);
 
     if (!isInteractive && isContentfulTemplate(templateSource) && normalizedOptions.action) {
-      await cloneAppAction(fullAppFolder, !!normalizedOptions.typescript);
+      await cloneAppAction(fullAppFolder, !normalizedOptions.javascript);
     }
 
     if (


### PR DESCRIPTION
Previously, in order to use `--deliveryFunction` or `--action` option, user needed to specify also `--javascript` or `--typescript` option. If no such option was provided then regular interactive session was started.
After this change `--typescript` option will be automatically assumed. Typescript was chosen because it is already the default template for other options.