### PR TITLE
chore: add .nx folder to .gitignore []

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ lerna-debug.log*
 dist
 /dependency-check
 
+.nx
+
 # editors
 .idea
 .vscode


### PR DESCRIPTION
After bootstrapping the project a new folder `.nx` with a bunch of files inside is created. In order to not accidentally commit it I have added it to the `.gitignore` file.