### PR TITLE
chore: update the templates list [MONET-1564]

### DIFF
--- a/packages/contentful--create-contentful-app/src/constants.ts
+++ b/packages/contentful--create-contentful-app/src/constants.ts
@@ -1,7 +1,7 @@
 export const CREATE_APP_DEFINITION_GUIDE_URL =
   'https://ctfl.io/app-tutorial#embed-your-app-in-the-contentful-web-app';
 export const EXAMPLES_REPO_URL = 'https://github.com/contentful/apps/tree/master/examples';
-export const TEMPLATES = [
+export const IGNORED_EXAMPLE_FOLDERS = [
   'javascript',
   'typescript',
   'vue',

--- a/packages/contentful--create-contentful-app/src/constants.ts
+++ b/packages/contentful--create-contentful-app/src/constants.ts
@@ -1,10 +1,15 @@
 export const CREATE_APP_DEFINITION_GUIDE_URL =
   'https://ctfl.io/app-tutorial#embed-your-app-in-the-contentful-web-app';
 export const EXAMPLES_REPO_URL = 'https://github.com/contentful/apps/tree/master/examples';
-export const TEMPLATES = ['javascript', 'typescript', 'vue', 'vite-react', 'nextjs'] as const;
+export const TEMPLATES = [
+  'javascript',
+  'typescript',
+  'vue',
+  'vite-react',
+  'nextjs',
+  'hosted-app-action-templates',
+  'hosted-delivery-function-templates',
+] as const;
 export const EXAMPLES_PATH = 'contentful/apps/examples/';
 export const CONTENTFUL_APP_MANIFEST = 'contentful-app-manifest.json';
-export const IGNORED_CLONED_FILES = [
-  CONTENTFUL_APP_MANIFEST,
-  `package.json`
-]
+export const IGNORED_CLONED_FILES = [CONTENTFUL_APP_MANIFEST, `package.json`];

--- a/packages/contentful--create-contentful-app/src/getTemplateSource.ts
+++ b/packages/contentful--create-contentful-app/src/getTemplateSource.ts
@@ -3,7 +3,7 @@ import inquirer from 'inquirer';
 import chalk from 'chalk';
 import { CLIOptions, ContentfulExample } from './types';
 import { highlight, warn, wrapInBlanks } from './logger';
-import { EXAMPLES_PATH, TEMPLATES } from './constants';
+import { EXAMPLES_PATH, IGNORED_EXAMPLE_FOLDERS } from './constants';
 import { isContentfulTemplate } from './utils';
 
 const CONTENTFUL_APPS_EXAMPLE_FOLDER =
@@ -14,7 +14,7 @@ async function getGithubFolderNames() {
   const contents = await response.json();
 
   return contents
-    .filter((content: any) => content.type === 'dir' && !TEMPLATES.includes(content.name))
+    .filter((content: any) => content.type === 'dir' && !IGNORED_EXAMPLE_FOLDERS.includes(content.name))
     .map((content: any) => content.name);
 }
 


### PR DESCRIPTION
Because `hosted-app-action-templates` and `hosted-delivery-function-templates` are templates, not examples it was not possible to successfully clone them in case user selected them from examples list. By filtering them out we will avoid confusion when choosing examples from the list.