### PR TITLE
fix: stop org spinner after fetching organizations

### DIFF
--- a/packages/contentful--app-scripts/src/organization-api.ts
+++ b/packages/contentful--app-scripts/src/organization-api.ts
@@ -29,6 +29,7 @@ export async function selectOrganization(client: ClientAPI): Promise<Organizatio
 
   try {
     const organizations = await fetchOrganizations(client);
+    orgSpinner.stop();
     return await selectFromList(organizations, 'Select an organization:', ORG_ID_ENV_KEY);
   } finally {
     orgSpinner.stop();


### PR DESCRIPTION
This fixes an issue where the "Fetching your organizations..." spinner continues to run while the user is selecting from the list of returned organizations.