### PR TITLE
feat: add app event filter to function manifest accepts param [EXT-5079]

### DIFF
--- a/packages/contentful--app-scripts/src/utils.test.ts
+++ b/packages/contentful--app-scripts/src/utils.test.ts
@@ -206,7 +206,7 @@ describe('get functions from manifest', () => {
     path: 'functions/mock.js',
     entryFile: './functions/mock.ts',
     allowNetworks: ['127.0.0.1', 'some.domain.tld'],
-    accepts: ["graphql.field.mapping", "graphql.query"]
+    accepts: ["graphql.field.mapping", "graphql.query", 'appevent.filter']
   };
   // eslint-disable-next-line no-unused-vars
   const { entryFile: _, ...resultMock } = functionMock;

--- a/packages/contentful--app-scripts/src/utils.ts
+++ b/packages/contentful--app-scripts/src/utils.ts
@@ -110,6 +110,7 @@ export function getEntityFromManifest<Type extends 'actions' | 'functions'>(type
 
     const fieldMappingEvent = "graphql.field.mapping";
     const queryEvent =  "graphql.query";
+    const appEventFilter = 'appevent.filter';
 
     const items = (manifest[type] as FunctionAppAction[] | ContentfulFunction[]).map((item) => {
       const allowNetworks = Array.isArray(item.allowNetworks)
@@ -117,7 +118,7 @@ export function getEntityFromManifest<Type extends 'actions' | 'functions'>(type
         : [];
 
       const accepts = 'accepts' in item && Array.isArray(item.accepts) ? item.accepts : undefined;
-      const hasInvalidEvent = accepts?.some((event) => ![fieldMappingEvent, queryEvent].includes(event));
+      const hasInvalidEvent = accepts?.some((event) => ![fieldMappingEvent, queryEvent, appEventFilter].includes(event));
 
       const hasInvalidNetwork = allowNetworks.find((netWork) => !isValidNetwork(netWork));
       if (hasInvalidNetwork) {


### PR DESCRIPTION
This PR adds an additional valid event to the `accepts` parameter when defining functions in the `contentful-app-manifest.json` file.