### PR TITLE
validate whether the function/action entry points exist in the bundle [MONET-1987]

### DIFF
--- a/packages/contentful--app-scripts/src/upload/create-app-upload.ts
+++ b/packages/contentful--app-scripts/src/upload/create-app-upload.ts
@@ -6,13 +6,17 @@ import { createClient } from 'contentful-management';
 import { UploadSettings } from '../types';
 
 async function createAppBundleFromFile(orgId: string, token: string, zip: Buffer, host = '') {
-  const client = createClient({ accessToken: token, host, hostUpload: host.replace(/^api/i, 'upload') });
+  const client = createClient({
+    accessToken: token,
+    host,
+    hostUpload: host.replace(/^api/i, 'upload'),
+  });
   const org = await client.getOrganization(orgId);
   return await org.createAppUpload(zip);
 }
 
 export async function createAppUpload(settings: UploadSettings) {
-  validateBundle(settings.bundleDirectory || '.');
+  validateBundle(settings.bundleDirectory || '.', settings);
   let appUpload = null;
   const zipFileSpinner = ora('Preparing your files for upload...').start();
   const zipFile = await createZipFileFromDirectory(settings.bundleDirectory || '../types');

--- a/packages/contentful--app-scripts/src/upload/validate-bundle.test.ts
+++ b/packages/contentful--app-scripts/src/upload/validate-bundle.test.ts
@@ -1,6 +1,7 @@
 import sinon, { SinonStub } from 'sinon';
 import proxyquire from 'proxyquire';
 import assert from 'assert';
+import { UploadSettings } from '../types';
 
 describe('validateBundle', () => {
   beforeEach(() => {
@@ -14,7 +15,7 @@ describe('validateBundle', () => {
     const fsstub = { readdirSync: () => [] };
     const { validateBundle } = proxyquire('./validate-bundle', { fs: fsstub });
     try {
-      validateBundle('build');
+      validateBundle('build', {});
     } catch (e: any) {
       assert.strictEqual(
         e.message,
@@ -29,7 +30,7 @@ describe('validateBundle', () => {
       readFileSync: () => '<html><script src="/absolute/path"></script></html>',
     };
     const { validateBundle } = proxyquire('./validate-bundle', { fs: fsstub });
-    validateBundle('build');
+    validateBundle('build', {});
     assert((console.warn as SinonStub).calledWith(sinon.match(/absolute paths/)));
   });
 
@@ -39,7 +40,51 @@ describe('validateBundle', () => {
       readFileSync: () => '<html><script src="./relative/path"></script></html>',
     };
     const { validateBundle } = proxyquire('./validate-bundle', { fs: fsstub });
-    validateBundle('build');
-    sinon.assert.notCalled((console.warn as SinonStub))
+    validateBundle('build', {});
+    sinon.assert.notCalled(console.warn as SinonStub);
+  });
+
+  it('throws when there is no entry point for a function defined in the contentful-app-manifest.json', () => {
+    const mockedSettings = {
+      functions: [
+        { id: 'myFunc', path: 'functions/myFunc.js' },
+        { id: 'myOtherFunc', path: 'functions/myOtherFunc.js' },
+      ],
+    } as Pick<UploadSettings, 'functions' | 'actions'>;
+    const fsstub = {
+      readdirSync: () => ['index.html', 'functions', 'functions/myFunc.js'],
+      readFileSync: () => '<html><script src="./relative/path"></script></html>',
+    };
+    const { validateBundle } = proxyquire('./validate-bundle', { fs: fsstub });
+    try {
+      validateBundle('build', mockedSettings);
+    } catch (e: any) {
+      assert.strictEqual(
+        e.message,
+        'Function "myOtherFunc" is missing its entry file at "build/functions/myOtherFunc.js".'
+      );
+    }
+  });
+
+  it('throws when there is no entry point for a function defined in the contentful-app-manifest.json', () => {
+    const mockedSettings = {
+      actions: [
+        { id: 'myAction', path: 'actions/myAction.js' },
+        { id: 'myOtherAction', path: 'actions/myOtherAction.js' },
+      ],
+    } as Pick<UploadSettings, 'functions' | 'actions'>;
+    const fsstub = {
+      readdirSync: () => ['index.html', 'actions', 'actions/myAction.js'],
+      readFileSync: () => '<html><script src="./relative/path"></script></html>',
+    };
+    const { validateBundle } = proxyquire('./validate-bundle', { fs: fsstub });
+    try {
+      validateBundle('build', mockedSettings);
+    } catch (e: any) {
+      assert.strictEqual(
+        e.message,
+        'Action "myOtherAction" is missing its entry file at "build/actions/myOtherAction.js".'
+      );
+    }
   });
 });

--- a/packages/contentful--app-scripts/src/upload/validate-bundle.ts
+++ b/packages/contentful--app-scripts/src/upload/validate-bundle.ts
@@ -1,9 +1,10 @@
 import Path from 'path';
 import fs from 'fs';
 import chalk from 'chalk';
+import { UploadSettings } from '../types';
 
 const ACCEPTED_ENTRY_FILES = ['index.html'];
-const getEntryFile = (files: string[]) => files.find(file => ACCEPTED_ENTRY_FILES.includes(file));
+const getEntryFile = (files: string[]) => files.find((file) => ACCEPTED_ENTRY_FILES.includes(file));
 
 const ABSOLUTE_PATH_REG_EXP = /(src|href)="\/([^/])([^"]*)+"/g;
 
@@ -11,10 +12,14 @@ const fileContainsAbsolutePath = (fileContent: string) => {
   return [...fileContent.matchAll(ABSOLUTE_PATH_REG_EXP)].length > 0;
 };
 
-export const validateBundle = (path: string) => {
+export const validateBundle = (
+  path: string,
+  { functions, actions }: Pick<UploadSettings, 'functions' | 'actions'>
+) => {
   const buildFolder = Path.join('./', path);
-  const files = fs.readdirSync(buildFolder);
+  const files = fs.readdirSync(buildFolder, { recursive: true, encoding: 'utf-8' });
   const entry = getEntryFile(files);
+
   if (!entry) {
     throw new Error('Make sure your bundle includes a valid index.html file in its root folder.');
   }
@@ -29,5 +34,29 @@ export const validateBundle = (path: string) => {
       )} This bundle uses absolute paths. Please use relative paths instead for correct rendering. See more details here https://www.contentful.com/developers/docs/extensibility/app-framework/app-bundle/#limitations`
     );
     console.log('----------------------------');
+  }
+
+  if (functions) {
+    const functionWithoutEntryFile = functions.find(({ path }) => !files.includes(path));
+    if (functionWithoutEntryFile) {
+      throw new Error(
+        `Function "${functionWithoutEntryFile.id}" is missing its entry file at "${Path.join(
+          buildFolder,
+          functionWithoutEntryFile.path
+        )}".`
+      );
+    }
+  }
+
+  if (actions) {
+    const actionWithoutEntryFile = actions.find(({ path }) => !files.includes(path));
+    if (actionWithoutEntryFile) {
+      throw new Error(
+        `Action "${actionWithoutEntryFile.id}" is missing its entry file at "${Path.join(
+          buildFolder,
+          actionWithoutEntryFile.path
+        )}".`
+      );
+    }
   }
 };

--- a/packages/contentful--create-contentful-app/package-lock.json
+++ b/packages/contentful--create-contentful-app/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
-        "@contentful/app-scripts": "1.17.0",
         "analytics-node": "^6.2.0",
         "chalk": "4.1.2",
         "commander": "12.0.0",
@@ -52,74 +51,11 @@
         "npm": ">=6"
       }
     },
-    "node_modules/@contentful/app-scripts": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.17.0.tgz",
-      "integrity": "sha512-/E/vVEhLs90U05dMyh2jp2sPxO/TmUAbiBnPETxjoPETxLOS9VbjNH5x6U6e1ALASHdWiSI7TliOOXzQuWaO/Q==",
-      "dependencies": {
-        "@segment/analytics-node": "^2.0.0",
-        "adm-zip": "0.5.12",
-        "bottleneck": "2.19.5",
-        "chalk": "4.1.2",
-        "commander": "12.0.0",
-        "contentful-management": "11.23.0",
-        "dotenv": "16.4.5",
-        "ignore": "5.3.1",
-        "inquirer": "8.2.6",
-        "lodash": "4.17.21",
-        "open": "8.4.2",
-        "ora": "5.4.1"
-      },
-      "bin": {
-        "contentful-app-scripts": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/@contentful/app-scripts/node_modules/axios": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/@contentful/app-scripts/node_modules/contentful-management": {
-      "version": "11.23.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.23.0.tgz",
-      "integrity": "sha512-WswhJ6OQ/b+TwwE7ljljgiFbMgvPJ8FZi/dqIEnSCpB+t3iNM9gX8eW2Cjw6L7DQkF7JzRQAALSAptZoS8wEWA==",
-      "dependencies": {
-        "@contentful/rich-text-types": "^16.3.0",
-        "@types/json-patch": "0.0.30",
-        "axios": "^1.6.2",
-        "contentful-sdk-core": "^8.1.0",
-        "fast-copy": "^3.0.0",
-        "lodash.isplainobject": "^4.0.6",
-        "type-fest": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@contentful/app-scripts/node_modules/type-fest": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.13.1.tgz",
-      "integrity": "sha512-ASMgM+Vf2cLwDMt1KXSkMUDSYCxtckDJs8zsaVF/mYteIsiARKCVtyXtcK38mIKbLTctZP8v6GMqdNaeI3fo7g==",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@contentful/rich-text-types": {
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.3.0.tgz",
       "integrity": "sha512-OfQmAu5bxE0CgQA3WlUleVej+ifFG/iXmB2DmUl4EyWyFue1aiIvfjxQhcDRSH4n1jUNMJ6L1wInZL8uV5m3TQ==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -250,25 +186,6 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
     },
-    "node_modules/@lukeed/csprng": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
-      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@lukeed/uuid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
-      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
-      "dependencies": {
-        "@lukeed/csprng": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -276,65 +193,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@segment/analytics-core": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.4.1.tgz",
-      "integrity": "sha512-kV0Pf33HnthuBOVdYNani21kYyj118Fn+9757bxqoksiXoZlYvBsFq6giNdCsKcTIE1eAMqNDq3xE1VQ0cfsHA==",
-      "dependencies": {
-        "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-generic-utils": "1.1.1",
-        "dset": "^3.1.2",
-        "tslib": "^2.4.1"
-      }
-    },
-    "node_modules/@segment/analytics-generic-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.1.1.tgz",
-      "integrity": "sha512-THTIzBPHnvu1HYJU3fARdJ3qIkukO3zDXsmDm+kAeUks5R9CBXOQ6rPChiASVzSmwAIIo5uFIXXnCraojlq/Gw==",
-      "dependencies": {
-        "tslib": "^2.4.1"
-      }
-    },
-    "node_modules/@segment/analytics-node": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-2.0.0.tgz",
-      "integrity": "sha512-DU25dmsTsMEQ/A1OxVr2vHpGUyUZ2wukH3dH9bYRgvQOlhnnRHBP9hB3smNLfygC0IU2CKhT1rP6CGtVfdf4Sg==",
-      "dependencies": {
-        "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-core": "1.4.1",
-        "@segment/analytics-generic-utils": "1.1.1",
-        "buffer": "^6.0.3",
-        "jose": "^5.1.0",
-        "node-fetch": "^2.6.7",
-        "tslib": "^2.4.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@segment/analytics-node/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/@segment/loosely-validate-event": {
@@ -474,7 +332,8 @@
     "node_modules/@types/json-patch": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/json-patch/-/json-patch-0.0.30.tgz",
-      "integrity": "sha512-MhCUjojzDhVLnZnxwPwa+rETFRDQ0ffjxYdrqOP6TBO2O0/Z64PV5tNeYApo4bc4y4frbWOrRwv/eEkXlI13Rw=="
+      "integrity": "sha512-MhCUjojzDhVLnZnxwPwa+rETFRDQ0ffjxYdrqOP6TBO2O0/Z64PV5tNeYApo4bc4y4frbWOrRwv/eEkXlI13Rw==",
+      "dev": true
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -597,14 +456,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/adm-zip": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.12.tgz",
-      "integrity": "sha512-6TVU49mK6KZb4qG6xWaaM4C7sA/sgUMLy/JYMOzkcp3BvVLpW0fXDFQiIzAuxFCt/2+xD7fNIiPFAoLZPhVNLQ==",
-      "engines": {
-        "node": ">=6.0"
       }
     },
     "node_modules/analytics-node": {
@@ -762,11 +613,6 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
-    },
-    "node_modules/bottleneck": {
-      "version": "2.19.5",
-      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
-      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -1045,6 +891,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.1.0.tgz",
       "integrity": "sha512-ZXTtrkrx4OlRcVY0WLihrskF+BSuHe7QZuWA8DNEeTlHmkPXAVch9Og5TJDoyGeqNrArR3Ovd7yfaG+1QYo+ag==",
+      "dev": true,
       "dependencies": {
         "fast-copy": "^2.1.7",
         "lodash.isplainobject": "^4.0.6",
@@ -1058,7 +905,8 @@
     "node_modules/contentful-sdk-core/node_modules/fast-copy": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
-      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
+      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA==",
+      "dev": true
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -1142,14 +990,6 @@
         "clone": "^1.0.2"
       }
     },
-    "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/degit": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/degit/-/degit-2.8.4.tgz",
@@ -1176,25 +1016,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/dset": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
-      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/eastasianwidth": {
@@ -1240,7 +1061,8 @@
     "node_modules/fast-copy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
-      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA=="
+      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+      "dev": true
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -1453,14 +1275,6 @@
         }
       ]
     },
-    "node_modules/ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1517,20 +1331,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -1605,17 +1405,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -1649,14 +1438,6 @@
       "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
       "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ=="
     },
-    "node_modules/jose": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.0.tgz",
-      "integrity": "sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw==",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
@@ -1677,7 +1458,8 @@
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
@@ -2108,22 +1890,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-      "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ora": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
@@ -2173,6 +1939,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-4.1.1.tgz",
       "integrity": "sha512-TuU8Ato+pRTPJoDzYD4s7ocJYcNSEZRvlxoq3hcPI2kZDZ49IQ1Wkj7/gDJc3X7XiEAAvRGtDzdXJI0tC3IL1g==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -2253,7 +2020,8 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -2847,60 +2615,11 @@
     }
   },
   "dependencies": {
-    "@contentful/app-scripts": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.17.0.tgz",
-      "integrity": "sha512-/E/vVEhLs90U05dMyh2jp2sPxO/TmUAbiBnPETxjoPETxLOS9VbjNH5x6U6e1ALASHdWiSI7TliOOXzQuWaO/Q==",
-      "requires": {
-        "@segment/analytics-node": "^2.0.0",
-        "adm-zip": "0.5.12",
-        "bottleneck": "2.19.5",
-        "chalk": "4.1.2",
-        "commander": "12.0.0",
-        "contentful-management": "11.23.0",
-        "dotenv": "16.4.5",
-        "ignore": "5.3.1",
-        "inquirer": "8.2.6",
-        "lodash": "4.17.21",
-        "open": "8.4.2",
-        "ora": "5.4.1"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "1.6.8",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
-          "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
-          "requires": {
-            "follow-redirects": "^1.15.6",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
-        "contentful-management": {
-          "version": "11.23.0",
-          "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.23.0.tgz",
-          "integrity": "sha512-WswhJ6OQ/b+TwwE7ljljgiFbMgvPJ8FZi/dqIEnSCpB+t3iNM9gX8eW2Cjw6L7DQkF7JzRQAALSAptZoS8wEWA==",
-          "requires": {
-            "@contentful/rich-text-types": "^16.3.0",
-            "@types/json-patch": "0.0.30",
-            "axios": "^1.6.2",
-            "contentful-sdk-core": "^8.1.0",
-            "fast-copy": "^3.0.0",
-            "lodash.isplainobject": "^4.0.6",
-            "type-fest": "^4.0.0"
-          }
-        },
-        "type-fest": {
-          "version": "4.13.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.13.1.tgz",
-          "integrity": "sha512-ASMgM+Vf2cLwDMt1KXSkMUDSYCxtckDJs8zsaVF/mYteIsiARKCVtyXtcK38mIKbLTctZP8v6GMqdNaeI3fo7g=="
-        }
-      }
-    },
     "@contentful/rich-text-types": {
       "version": "16.3.0",
       "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.3.0.tgz",
-      "integrity": "sha512-OfQmAu5bxE0CgQA3WlUleVej+ifFG/iXmB2DmUl4EyWyFue1aiIvfjxQhcDRSH4n1jUNMJ6L1wInZL8uV5m3TQ=="
+      "integrity": "sha512-OfQmAu5bxE0CgQA3WlUleVej+ifFG/iXmB2DmUl4EyWyFue1aiIvfjxQhcDRSH4n1jUNMJ6L1wInZL8uV5m3TQ==",
+      "dev": true
     },
     "@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -2993,68 +2712,11 @@
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
     },
-    "@lukeed/csprng": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
-      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="
-    },
-    "@lukeed/uuid": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
-      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
-      "requires": {
-        "@lukeed/csprng": "^1.1.0"
-      }
-    },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "optional": true
-    },
-    "@segment/analytics-core": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.4.1.tgz",
-      "integrity": "sha512-kV0Pf33HnthuBOVdYNani21kYyj118Fn+9757bxqoksiXoZlYvBsFq6giNdCsKcTIE1eAMqNDq3xE1VQ0cfsHA==",
-      "requires": {
-        "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-generic-utils": "1.1.1",
-        "dset": "^3.1.2",
-        "tslib": "^2.4.1"
-      }
-    },
-    "@segment/analytics-generic-utils": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.1.1.tgz",
-      "integrity": "sha512-THTIzBPHnvu1HYJU3fARdJ3qIkukO3zDXsmDm+kAeUks5R9CBXOQ6rPChiASVzSmwAIIo5uFIXXnCraojlq/Gw==",
-      "requires": {
-        "tslib": "^2.4.1"
-      }
-    },
-    "@segment/analytics-node": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-2.0.0.tgz",
-      "integrity": "sha512-DU25dmsTsMEQ/A1OxVr2vHpGUyUZ2wukH3dH9bYRgvQOlhnnRHBP9hB3smNLfygC0IU2CKhT1rP6CGtVfdf4Sg==",
-      "requires": {
-        "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-core": "1.4.1",
-        "@segment/analytics-generic-utils": "1.1.1",
-        "buffer": "^6.0.3",
-        "jose": "^5.1.0",
-        "node-fetch": "^2.6.7",
-        "tslib": "^2.4.1"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        }
-      }
     },
     "@segment/loosely-validate-event": {
       "version": "2.0.0",
@@ -3194,7 +2856,8 @@
     "@types/json-patch": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/json-patch/-/json-patch-0.0.30.tgz",
-      "integrity": "sha512-MhCUjojzDhVLnZnxwPwa+rETFRDQ0ffjxYdrqOP6TBO2O0/Z64PV5tNeYApo4bc4y4frbWOrRwv/eEkXlI13Rw=="
+      "integrity": "sha512-MhCUjojzDhVLnZnxwPwa+rETFRDQ0ffjxYdrqOP6TBO2O0/Z64PV5tNeYApo4bc4y4frbWOrRwv/eEkXlI13Rw==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.5",
@@ -3308,11 +2971,6 @@
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "dev": true
     },
-    "adm-zip": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.12.tgz",
-      "integrity": "sha512-6TVU49mK6KZb4qG6xWaaM4C7sA/sgUMLy/JYMOzkcp3BvVLpW0fXDFQiIzAuxFCt/2+xD7fNIiPFAoLZPhVNLQ=="
-    },
     "analytics-node": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.2.0.tgz",
@@ -3424,11 +3082,6 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
-    },
-    "bottleneck": {
-      "version": "2.19.5",
-      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
-      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
     "brace-expansion": {
       "version": "2.0.1",
@@ -3630,6 +3283,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.1.0.tgz",
       "integrity": "sha512-ZXTtrkrx4OlRcVY0WLihrskF+BSuHe7QZuWA8DNEeTlHmkPXAVch9Og5TJDoyGeqNrArR3Ovd7yfaG+1QYo+ag==",
+      "dev": true,
       "requires": {
         "fast-copy": "^2.1.7",
         "lodash.isplainobject": "^4.0.6",
@@ -3640,7 +3294,8 @@
         "fast-copy": {
           "version": "2.1.7",
           "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
-          "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
+          "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA==",
+          "dev": true
         }
       }
     },
@@ -3705,11 +3360,6 @@
         "clone": "^1.0.2"
       }
     },
-    "define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
-    },
     "degit": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/degit/-/degit-2.8.4.tgz",
@@ -3725,16 +3375,6 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
-    },
-    "dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="
-    },
-    "dset": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.3.tgz",
-      "integrity": "sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ=="
     },
     "eastasianwidth": {
       "version": "0.2.0",
@@ -3770,7 +3410,8 @@
     "fast-copy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.1.tgz",
-      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA=="
+      "integrity": "sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==",
+      "dev": true
     },
     "figures": {
       "version": "3.2.0",
@@ -3896,11 +3537,6 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
-    "ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw=="
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3952,11 +3588,6 @@
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
-    "is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
-    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4003,14 +3634,6 @@
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
     },
-    "is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "requires": {
-        "is-docker": "^2.0.0"
-      }
-    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -4036,11 +3659,6 @@
       "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
       "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ=="
     },
-    "jose": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.0.tgz",
-      "integrity": "sha512-oW3PCnvyrcm1HMvGTzqjxxfnEs9EoFOFWi2HsEGhlFVOXxTE3K9GKWVMFoFw06yPUqwpvEWic1BmtUZBI/tIjw=="
-    },
     "just-extend": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
@@ -4061,7 +3679,8 @@
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
     },
     "lodash.isstring": {
       "version": "4.0.1",
@@ -4387,16 +4006,6 @@
         "mimic-fn": "^2.1.0"
       }
     },
-    "open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
-      "requires": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
-        "is-wsl": "^2.2.0"
-      }
-    },
     "ora": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
@@ -4430,7 +4039,8 @@
     "p-throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-4.1.1.tgz",
-      "integrity": "sha512-TuU8Ato+pRTPJoDzYD4s7ocJYcNSEZRvlxoq3hcPI2kZDZ49IQ1Wkj7/gDJc3X7XiEAAvRGtDzdXJI0tC3IL1g=="
+      "integrity": "sha512-TuU8Ato+pRTPJoDzYD4s7ocJYcNSEZRvlxoq3hcPI2kZDZ49IQ1Wkj7/gDJc3X7XiEAAvRGtDzdXJI0tC3IL1g==",
+      "dev": true
     },
     "path-exists": {
       "version": "4.0.0",
@@ -4483,7 +4093,8 @@
     "proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",


### PR DESCRIPTION
When the user forgets to run `npm run build` or did not correctly call the `build-functions.js` the CLI still tries to upload the function without any entry file. This results in an error in app-upload-to-delivery which results in a 500 (Internal Server error) response from extensiblity-api.