### PR TITLE
fix: publish create-contentful-app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,8 @@ commands:
       - checkout
       - vault/get-secrets:
           template-preset: 'semantic-release'
+      - vault/get-secrets:
+          template-preset: 'semantic-release-ecosystem'
       - vault/configure-lerna
       - run: echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_WRITE_TOKEN}" > ~/.npmrc
       - run: echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc


### PR DESCRIPTION
CI attempts to publish the unscoped `create-contentful-app` directly to npm, but errors with a 429 at npm's API, which we actually suspect to be an auth issue