### PR TITLE
fix: cli defaults function flag to external references

### DIFF
--- a/packages/contentful--create-contentful-app/src/index.ts
+++ b/packages/contentful--create-contentful-app/src/index.ts
@@ -131,6 +131,12 @@ async function initProject(appName: string, options: CLIOptions) {
     }
 
     if (!isInteractive && isContentfulTemplate(templateSource) && normalizedOptions.function) {
+      // If function flag is specified, but no function name is provided, we default to external-references
+      // for legacy support.
+      if (normalizedOptions.function === true) {
+        normalizedOptions.function = 'external-references';
+      }
+
       await cloneFunction(
         fullAppFolder,
         !!normalizedOptions.javascript,
@@ -194,7 +200,7 @@ async function initProject(appName: string, options: CLIOptions) {
       ].join('\n')
     )
     .option('-a, --action', 'include a hosted app action in the ts or js template')
-    .option('-f, --function <function-template-name>', 'include the specified function template')
+    .option('-f, --function [function-template-name]', 'include the specified function template')
     .action(initProject);
   await program.parseAsync();
 })();

--- a/packages/contentful--create-contentful-app/src/types.ts
+++ b/packages/contentful--create-contentful-app/src/types.ts
@@ -6,7 +6,7 @@ export type CLIOptions = Partial<{
   source: string;
   example: string;
   action: boolean;
-  function: string;
+  function: string | boolean;
 }>;
 
 export const ContentfulExample = {


### PR DESCRIPTION
- changes `--function` flag to not require a value. If one is not provided, default to external-references.