### PR TITLE
fix: remove unnecessary `console.log` statement

### DIFF
--- a/packages/contentful--app-scripts/src/open/open-settings.ts
+++ b/packages/contentful--app-scripts/src/open/open-settings.ts
@@ -22,10 +22,6 @@ export async function openSettings(options: OpenSettingsOptions) {
     definitionId = prompts.definitionId;
   }
 
-  console.log(definitionId, 'DEFID');
-  console.log(options, 'options');
-  console.log(process.env[APP_DEF_ENV_KEY], 'process.env[APP_DEF_ENV_KEY]');
-
   if (!definitionId) {
     console.log(`
         ${chalk.red('Error:')} There was no app-definition defined.


### PR DESCRIPTION
This wasn't intended to end up in a release, hence removing it.