### PR TITLE
Feat: add a script to install the app

### DIFF
--- a/packages/contentful--app-scripts/README.md
+++ b/packages/contentful--app-scripts/README.md
@@ -238,6 +238,14 @@ You can also execute this command without the argument if the environment variab
 > $ CONTENTFUL_APP_DEF_ID=some-definition-id npx --no-install @contentful/app-scripts install
 > ```
 
+By default, the script will install the app into the default host URL: `app.contentful.com`. If you want to install the app into a different host URL, you can set the argument `--host` to the desired host URL.
+
+> **Example**
+>
+> ```shell
+> $ npx --no-install @contentful/app-scripts install --definition-id some-definition-id --host api.eu.contentful.com
+> ```
+
 ### Tracking
 
 We gather depersonalized usage data of our CLI tools in order to improve experience. If you do not want your data to be gathered, you can opt out by providing an env variable `DISABLE_ANALYTICS` set to any value:

--- a/packages/contentful--app-scripts/README.md
+++ b/packages/contentful--app-scripts/README.md
@@ -220,6 +220,24 @@ When passing the `--ci` argument adding all variables as arguments is required
 
 **Note:** You can also pass all arguments in interactive mode to skip being asked for it.
 
+### Install the AppDefinition into a specific space / environment
+
+It opens a dialog to select the space and environment where the app associated with the given [AppDefinition](https://www.contentful.com/developers/docs/extensibility/app-framework/app-definition/) should be installed.
+
+> **Example**
+>
+> ```shell
+> $ npx --no-install @contentful/app-scripts install --definition-id some-definition-id
+> ```
+
+You can also execute this command without the argument if the environment variable (`CONTENTFUL_APP_DEF_ID`) has been set.
+
+> **Example**
+>
+> ```shell
+> $ CONTENTFUL_APP_DEF_ID=some-definition-id npx --no-install @contentful/app-scripts install
+> ```
+
 ### Tracking
 
 We gather depersonalized usage data of our CLI tools in order to improve experience. If you do not want your data to be gathered, you can opt out by providing an env variable `DISABLE_ANALYTICS` set to any value:

--- a/packages/contentful--app-scripts/src/bin.ts
+++ b/packages/contentful--app-scripts/src/bin.ts
@@ -2,10 +2,16 @@
 
 import { program } from 'commander';
 
-import { createAppDefinition, upload, activate, cleanup, open, track } from './index';
+import { createAppDefinition, upload, activate, cleanup, open, track, install } from './index';
 import { feedback } from './feedback';
 
-type Command = typeof createAppDefinition | typeof upload | typeof activate | typeof cleanup | typeof open;
+type Command =
+  | typeof createAppDefinition
+  | typeof upload
+  | typeof activate
+  | typeof cleanup
+  | typeof open
+  | typeof install;
 
 async function runCommand(command: Command, options?: any) {
   const { ci } = program.opts();
@@ -68,12 +74,22 @@ async function runCommand(command: Command, options?: any) {
     .action(async (options) => {
       await runCommand(cleanup, options);
     });
-  
+
   program
     .command('feedback')
     .description('Provide Contentful with feedback on the CLI')
     .action(async (options) => {
       await runCommand(feedback, options);
+    });
+
+  program
+    .command('install')
+    .description(
+      'Opens a picker to select the space and environment for installing the app associated with a given AppDefinition'
+    )
+    .option('--definition-id  [defId]', 'The id of your apps definition')
+    .action(async (options) => {
+      await runCommand(install, options);
     });
 
   program.hook('preAction', (thisCommand) => {

--- a/packages/contentful--app-scripts/src/bin.ts
+++ b/packages/contentful--app-scripts/src/bin.ts
@@ -88,6 +88,7 @@ async function runCommand(command: Command, options?: any) {
       'Opens a picker to select the space and environment for installing the app associated with a given AppDefinition'
     )
     .option('--definition-id  [defId]', 'The id of your apps definition')
+    .option('--host [host]', 'Contentful domain to use')
     .action(async (options) => {
       await runCommand(install, options);
     });

--- a/packages/contentful--app-scripts/src/constants.ts
+++ b/packages/contentful--app-scripts/src/constants.ts
@@ -8,3 +8,4 @@ export const DEFAULT_BUNDLES_TO_FETCH = 1000;
 export const MAX_CONCURRENT_DELETION_CALLS = 5;
 
 export const DEFAULT_CONTENTFUL_API_HOST = 'api.contentful.com';
+export const DEFAULT_CONTENTFUL_APP_HOST = 'app.contentful.com';

--- a/packages/contentful--app-scripts/src/index.ts
+++ b/packages/contentful--app-scripts/src/index.ts
@@ -5,3 +5,4 @@ export { cleanup } from './clean-up';
 export { open } from './open';
 export { track } from './analytics';
 export { feedback } from './feedback';
+export { install } from './install';

--- a/packages/contentful--app-scripts/src/install/index.ts
+++ b/packages/contentful--app-scripts/src/install/index.ts
@@ -1,0 +1,15 @@
+import { InstallOptions } from '../types';
+import { installToEnvironment } from './install';
+
+const interactive = async (options: InstallOptions) => {
+  installToEnvironment(options);
+};
+
+const nonInteractive = async () => {
+  throw new Error(`"install" is not available in non-interactive mode`);
+};
+
+export const install = {
+  interactive,
+  nonInteractive,
+};

--- a/packages/contentful--app-scripts/src/install/install.test.ts
+++ b/packages/contentful--app-scripts/src/install/install.test.ts
@@ -2,9 +2,9 @@ import { SinonStub, stub } from 'sinon';
 import assert from 'assert';
 import { APP_DEF_ENV_KEY } from '../constants';
 import proxyquire from 'proxyquire';
-import { REDIRECT_URL } from './install';
 
 const TEST_DEF_ID = 'test-def-id';
+const TEST_HOST = 'test.host.com';
 
 describe('install', () => {
   let subject: typeof import('./install').installToEnvironment,
@@ -29,19 +29,33 @@ describe('install', () => {
     }));
   });
 
-  it('works with option passed', () => {
+  it('works with an app ID option passed', () => {
     subject({ definitionId: TEST_DEF_ID });
-    assert(installMock.calledWith(`${REDIRECT_URL}&id=${TEST_DEF_ID}`));
+    assert(
+      installMock.calledWith(`https://app.contentful.com/deeplink?link=apps&id=${TEST_DEF_ID}`)
+    );
   });
 
-  it('shows prompt when no definition is provided', () => {
+  it('works with both host and app ID options passed', () => {
+    subject({ host: TEST_HOST, definitionId: TEST_DEF_ID });
+    assert(installMock.calledWith(`https://${TEST_HOST}/deeplink?link=apps&id=${TEST_DEF_ID}`));
+  });
+
+  it('shows prompt when no app definition is provided', () => {
     subject({});
+    assert.strictEqual(inquirerMock.called, true);
+  });
+
+  it('shows prompt when host is provided, but no app definition', () => {
+    subject({ host: TEST_HOST });
     assert.strictEqual(inquirerMock.called, true);
   });
 
   it('works with env variable set', () => {
     process.env[APP_DEF_ENV_KEY] = TEST_DEF_ID;
     subject({});
-    assert(installMock.calledWith(`${REDIRECT_URL}&id=${TEST_DEF_ID}`));
+    assert(
+      installMock.calledWith(`https://app.contentful.com/deeplink?link=apps&id=${TEST_DEF_ID}`)
+    );
   });
 });

--- a/packages/contentful--app-scripts/src/install/install.test.ts
+++ b/packages/contentful--app-scripts/src/install/install.test.ts
@@ -1,0 +1,47 @@
+import { SinonStub, stub } from 'sinon';
+import assert from 'assert';
+import { APP_DEF_ENV_KEY } from '../constants';
+import proxyquire from 'proxyquire';
+import { REDIRECT_URL } from './install';
+
+const TEST_DEF_ID = 'test-def-id';
+
+describe('install', () => {
+  let subject: typeof import('./install').installToEnvironment,
+    installMock: SinonStub,
+    inquirerMock: SinonStub;
+  beforeEach(() => {
+    delete process.env[APP_DEF_ENV_KEY];
+    stub(console, 'log');
+  });
+
+  afterEach(() => {
+    (console.log as SinonStub).restore();
+    delete process.env[APP_DEF_ENV_KEY];
+  });
+
+  beforeEach(() => {
+    installMock = stub();
+    inquirerMock = stub();
+    ({ installToEnvironment: subject } = proxyquire('./install', {
+      open: installMock,
+      inquirer: { prompt: inquirerMock },
+    }));
+  });
+
+  it('works with option passed', () => {
+    subject({ definitionId: TEST_DEF_ID });
+    assert(installMock.calledWith(`${REDIRECT_URL}&id=${TEST_DEF_ID}`));
+  });
+
+  it('shows prompt when no definition is provided', () => {
+    subject({});
+    assert.strictEqual(inquirerMock.called, true);
+  });
+
+  it('works with env variable set', () => {
+    process.env[APP_DEF_ENV_KEY] = TEST_DEF_ID;
+    subject({});
+    assert(installMock.calledWith(`${REDIRECT_URL}&id=${TEST_DEF_ID}`));
+  });
+});

--- a/packages/contentful--app-scripts/src/install/install.ts
+++ b/packages/contentful--app-scripts/src/install/install.ts
@@ -1,0 +1,42 @@
+import open from 'open';
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+import { APP_DEF_ENV_KEY } from '../constants';
+import { InstallOptions } from '../types';
+
+export const REDIRECT_URL = 'https://app.contentful.com/deeplink?link=apps';
+
+export async function installToEnvironment(options: InstallOptions) {
+  let definitionId;
+  if (options.definitionId) {
+    definitionId = options.definitionId;
+  } else if (process.env[APP_DEF_ENV_KEY]) {
+    definitionId = process.env[APP_DEF_ENV_KEY];
+  } else {
+    const prompts = await inquirer.prompt([
+      {
+        name: 'definitionId',
+        message: `The id of the app:`,
+      },
+    ]);
+    definitionId = prompts.definitionId;
+  }
+
+  if (!definitionId) {
+    console.log(`
+        ${chalk.red('Error:')} There was no app-definition defined.
+
+        Please add it with ${chalk.cyan('--definition-id=<app-definition-id>')}
+        or set the environment variable ${chalk.cyan(`${APP_DEF_ENV_KEY} = <app-definition-id>`)}
+      `);
+    throw new Error('No app-definition-id');
+  }
+
+  try {
+    open(`${REDIRECT_URL}&id=${definitionId}`);
+  } catch (err: any) {
+    console.log(`${chalk.red('Error:')} Failed to open browser`);
+    console.log(err.message);
+    throw err;
+  }
+}

--- a/packages/contentful--app-scripts/src/install/install.ts
+++ b/packages/contentful--app-scripts/src/install/install.ts
@@ -1,10 +1,8 @@
 import open from 'open';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
-import { APP_DEF_ENV_KEY } from '../constants';
+import { APP_DEF_ENV_KEY, DEFAULT_CONTENTFUL_APP_HOST } from '../constants';
 import { InstallOptions } from '../types';
-
-export const REDIRECT_URL = 'https://app.contentful.com/deeplink?link=apps';
 
 export async function installToEnvironment(options: InstallOptions) {
   let definitionId;
@@ -32,8 +30,11 @@ export async function installToEnvironment(options: InstallOptions) {
     throw new Error('No app-definition-id');
   }
 
+  const host = options.host || DEFAULT_CONTENTFUL_APP_HOST;
+  const redirectUrl = `https://${host}/deeplink?link=apps`;
+
   try {
-    open(`${REDIRECT_URL}&id=${definitionId}`);
+    open(`${redirectUrl}&id=${definitionId}`);
   } catch (err: any) {
     console.log(`${chalk.red('Error:')} Failed to open browser`);
     console.log(err.message);

--- a/packages/contentful--app-scripts/src/types.ts
+++ b/packages/contentful--app-scripts/src/types.ts
@@ -60,6 +60,7 @@ export interface OpenSettingsOptions {
 
 export interface InstallOptions {
   definitionId?: string;
+  host?: string;
 }
 
 export interface UploadOptions {

--- a/packages/contentful--app-scripts/src/types.ts
+++ b/packages/contentful--app-scripts/src/types.ts
@@ -58,6 +58,10 @@ export interface OpenSettingsOptions {
   definitionId?: string;
 }
 
+export interface InstallOptions {
+  definitionId?: string;
+}
+
 export interface UploadOptions {
   organizationId?: string;
   definitionId?: string;


### PR DESCRIPTION
Based on the `open` script, I created a similar `install` script that opens the page where user can specify which space / environment they want the app to be installed to.