### PR TITLE
Extend the list of accepted events with ERL events

### DIFF
--- a/packages/contentful--app-scripts/src/utils.ts
+++ b/packages/contentful--app-scripts/src/utils.ts
@@ -8,9 +8,11 @@ import { ContentfulFunction, FunctionAppAction } from './types';
 
 const DEFAULT_MANIFEST_PATH = './contentful-app-manifest.json';
 
-const graphQLEvents = {
+const functionEvents = {
   fieldMappingEvent: 'graphql.field.mapping',
   queryEvent: 'graphql.query',
+  resourceLinksSearchEvent: 'resources.search',
+  resourceLinksLookupEvent: 'resources.lookup',
 };
 
 const appEvents = {
@@ -130,7 +132,7 @@ export function getEntityFromManifest<Type extends 'actions' | 'functions'>(
 
       const accepts = 'accepts' in item && Array.isArray(item.accepts) ? item.accepts : undefined;
       const hasInvalidEvent = accepts?.some(
-        (event) => ![...Object.values(graphQLEvents), ...Object.values(appEvents)].includes(event)
+        (event) => ![...Object.values(functionEvents), ...Object.values(appEvents)].includes(event)
       );
 
       const hasInvalidNetwork = allowNetworks.find((netWork) => !isValidNetwork(netWork));


### PR DESCRIPTION
Extensible Resource Links are introducing two new event types for functions (`resources.search` and `resources.lookup`), and we want the manifest validation to accept these as well.

Ticket: https://contentful.atlassian.net/browse/DANTE-1589