### PR TITLE
chore: update Node.js version requirement to >=20 in package.json

### DIFF
--- a/packages/contentful--app-scripts/package.json
+++ b/packages/contentful--app-scripts/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/contentful--app-scripts"
   },
   "engines": {
-    "node": ">=14",
+    "node": ">=20",
     "npm": ">=6"
   },
   "main": "lib/index.js",


### PR DESCRIPTION
Recently found the app scripts bundle validator uses `readdirsync` with `recursive=true`

this is only available in node>=20