### PR TITLE
feat: allow appaction.call events in the accepts field [EXT-5360]

### DIFF
--- a/packages/contentful--app-scripts/src/utils.ts
+++ b/packages/contentful--app-scripts/src/utils.ts
@@ -13,12 +13,10 @@ const functionEvents = {
   queryEvent: 'graphql.query',
   resourceLinksSearchEvent: 'resources.search',
   resourceLinksLookupEvent: 'resources.lookup',
-};
-
-const appEvents = {
   appEventFilter: 'appevent.filter',
   appEventHandler: 'appevent.handler',
   appEventTransformation: 'appevent.transformation',
+  appActionCall: 'appaction.call',
 };
 
 export const throwValidationException = (subject: string, message?: string, details?: string) => {
@@ -132,7 +130,7 @@ export function getEntityFromManifest<Type extends 'actions' | 'functions'>(
 
       const accepts = 'accepts' in item && Array.isArray(item.accepts) ? item.accepts : undefined;
       const hasInvalidEvent = accepts?.some(
-        (event) => ![...Object.values(functionEvents), ...Object.values(appEvents)].includes(event)
+        (event) => !Object.values(functionEvents).includes(event)
       );
 
       const hasInvalidNetwork = allowNetworks.find((netWork) => !isValidNetwork(netWork));


### PR DESCRIPTION
A new Contentful Function event type (`appaction.call`) will soon be available. This change just ensures the app scripts tooling does not block uploads that contain app manifests with functions that accept these new events. 