### PR TITLE
feat: strip protocol from host if provided during upload [EXT-00]

### DIFF
--- a/packages/contentful--app-scripts/src/upload/build-upload-settings.test.ts
+++ b/packages/contentful--app-scripts/src/upload/build-upload-settings.test.ts
@@ -22,13 +22,14 @@ describe('buildAppUploadSettings', () => {
     sinon.restore();
   });
 
-  it('should strip protocol from host input when provided via prompt', async () => {
+  for (const protocol of ['http://', 'https://']) {
+  it(`should strip ${protocol} protocol from host input when provided via prompt`, async () => {
     const options = {};
     const prompts = {
       bundleDirectory: './custom-build',
       comment: 'Test comment',
       activateBundle: true,
-      host: 'https://api.contentful.com',
+      host: `${protocol}api.contentful.com`,
     };
 
     // Manually apply the filter function to simulate inquirer's behavior
@@ -50,6 +51,7 @@ describe('buildAppUploadSettings', () => {
     assert.strictEqual(result.actions, 'actionsManifest');
     assert.strictEqual(result.functions, 'functionsManifest');
   });
+  }
 
   it('should prompt for missing options and use defaults', async () => {
     const options = {};

--- a/packages/contentful--app-scripts/src/upload/build-upload-settings.test.ts
+++ b/packages/contentful--app-scripts/src/upload/build-upload-settings.test.ts
@@ -1,0 +1,107 @@
+import assert from 'assert';
+import sinon from 'sinon';
+import inquirer from 'inquirer';
+
+import { buildAppUploadSettings, hostProtocolFilter } from './build-upload-settings';
+
+import * as getAppInfoModule from '../get-app-info';
+import * as utilsModule from '../utils';
+
+describe('buildAppUploadSettings', () => {
+  let promptStub;
+  let getAppInfoStub;
+  let getEntityFromManifestStub;
+
+  beforeEach(() => {
+    promptStub = sinon.stub(inquirer, 'prompt');
+    getAppInfoStub = sinon.stub(getAppInfoModule, 'getAppInfo');
+    getEntityFromManifestStub = sinon.stub(utilsModule, 'getEntityFromManifest');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should strip protocol from host input when provided via prompt', async () => {
+    const options = {};
+    const prompts = {
+      bundleDirectory: './custom-build',
+      comment: 'Test comment',
+      activateBundle: true,
+      host: 'https://api.contentful.com',
+    };
+
+    // Manually apply the filter function to simulate inquirer's behavior
+    prompts.host = hostProtocolFilter(prompts.host);
+
+    promptStub.resolves(prompts);
+
+    getAppInfoStub.resolves({ appId: '123', appName: 'Test App' });
+
+    getEntityFromManifestStub.withArgs('actions').returns('actionsManifest');
+    getEntityFromManifestStub.withArgs('functions').returns('functionsManifest');
+
+    const result = await buildAppUploadSettings(options);
+
+    assert.strictEqual(result.host, 'api.contentful.com', 'Protocol should be stripped from host');
+    assert.strictEqual(result.bundleDirectory, './custom-build');
+    assert.strictEqual(result.comment, 'Test comment');
+    assert.strictEqual(result.skipActivation, false); // activateBundle is true, so skipActivation should be false
+    assert.strictEqual(result.actions, 'actionsManifest');
+    assert.strictEqual(result.functions, 'functionsManifest');
+  });
+
+  it('should prompt for missing options and use defaults', async () => {
+    const options = {};
+    const prompts = {
+      bundleDirectory: './build',
+      comment: '',
+      activateBundle: true,
+      host: 'api.contentful.com',
+    };
+
+    promptStub.resolves(prompts);
+    getAppInfoStub.resolves({ appId: '123', appName: 'Test App' });
+    getEntityFromManifestStub.withArgs('actions').returns('actionsManifest');
+    getEntityFromManifestStub.withArgs('functions').returns('functionsManifest');
+
+    const result = await buildAppUploadSettings(options);
+
+    assert.strictEqual(result.bundleDirectory, './build');
+    assert.strictEqual(result.comment, '');
+    assert.strictEqual(result.skipActivation, false);
+    assert.strictEqual(result.host, 'api.contentful.com');
+  });
+
+  it('should handle skipActivation correctly when option is provided', async () => {
+    const options = {
+      skipActivation: true,
+    };
+
+    promptStub.resolves({});
+    getAppInfoStub.resolves({ appId: '123', appName: 'Test App' });
+    getEntityFromManifestStub.withArgs('actions').returns('actionsManifest');
+    getEntityFromManifestStub.withArgs('functions').returns('functionsManifest');
+
+    const result = await buildAppUploadSettings(options);
+
+    assert.strictEqual(result.skipActivation, true);
+  });
+
+  it('should correctly handle activateBundle prompt when skipActivation is undefined', async () => {
+    const options = {};
+    const prompts = {
+      activateBundle: false,
+      host: 'api.contentful.com',
+    };
+
+    promptStub.resolves(prompts);
+    getAppInfoStub.resolves({ appId: '123', appName: 'Test App' });
+    getEntityFromManifestStub.withArgs('actions').returns('actionsManifest');
+    getEntityFromManifestStub.withArgs('functions').returns('functionsManifest');
+
+    const result = await buildAppUploadSettings(options);
+
+    assert.strictEqual(result.skipActivation, true);
+  });
+});

--- a/packages/contentful--app-scripts/src/upload/build-upload-settings.ts
+++ b/packages/contentful--app-scripts/src/upload/build-upload-settings.ts
@@ -37,7 +37,7 @@ export async function buildAppUploadSettings(options: UploadOptions): Promise<Up
       name: 'host',
       message: `Contentful CMA endpoint URL:`,
       default: DEFAULT_CONTENTFUL_API_HOST,
-      filter: (input: string) => input.replace(/^https?:\/\//, ''),
+      filter: hostProtocolFilter,
     });
   }
 
@@ -55,4 +55,8 @@ export async function buildAppUploadSettings(options: UploadOptions): Promise<Up
     ...appUploadSettings,
     ...appInfo,
   };
+}
+
+export function hostProtocolFilter (input: string) {
+  return input.replace(/^https?:\/\//, '');
 }

--- a/packages/contentful--app-scripts/src/upload/build-upload-settings.ts
+++ b/packages/contentful--app-scripts/src/upload/build-upload-settings.ts
@@ -37,6 +37,7 @@ export async function buildAppUploadSettings(options: UploadOptions): Promise<Up
       name: 'host',
       message: `Contentful CMA endpoint URL:`,
       default: DEFAULT_CONTENTFUL_API_HOST,
+      filter: (input: string) => input.replace(/^https?:\/\//, ''),
     });
   }
 

--- a/packages/contentful--app-scripts/src/upload/create-app-upload.test.ts
+++ b/packages/contentful--app-scripts/src/upload/create-app-upload.test.ts
@@ -42,6 +42,7 @@ describe('createAppUpload', () => {
     const appUpload = await createAppUpload(mockedSettings);
     assert.strictEqual(appUpload, uploadMock);
   });
+
   it('shows creation error when createAppUpload throws', async () => {
     clientMock = {
       getOrganization: () => ({


### PR DESCRIPTION
This PR addresses an issue where specifying a host that starts with http:// or https:// causes the upload process to break. 

To fix this, an inquirer filter function has been added to the host prompt in `buildAppUploadSettings`. This function strips out any leading http:// or https:// from the user's input, ensuring that only the base URL is used. 