### PR TITLE
feat: support wildcard domains with regex [MONET-2345]

### DIFF
--- a/packages/contentful--app-scripts/src/utils.test.ts
+++ b/packages/contentful--app-scripts/src/utils.test.ts
@@ -10,6 +10,11 @@ describe('isValidIpAddress', () => {
     assert.strictEqual(result, true);
   });
 
+  it('returns true for a wildcard domain address', () => {
+    const result = isValidNetwork('*.cloudflare.com');
+    assert.strictEqual(result, true);
+  });
+
   it('returns true for a valid domain', () => {
     const result = isValidNetwork('google.com');
     assert.strictEqual(result, true);
@@ -43,6 +48,11 @@ describe('isValidIpAddress', () => {
   it('returns true for an valid ipv6 address with port', () => {
     const result = isValidNetwork('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]:443');
     assert.strictEqual(result, true);
+  });
+
+  it('returns false for an invalid wildcard domain address', () => {
+    const result = isValidNetwork('*.128.0.1');
+    assert.strictEqual(result, false);
   });
 });
 
@@ -125,7 +135,7 @@ describe('get actions from manifest', () => {
     fs.readFileSync.returns(
       JSON.stringify({
         actions: [actionMock],
-      }),
+      })
     );
 
     const result = getEntityFromManifest('actions');
@@ -145,7 +155,7 @@ describe('get actions from manifest', () => {
     fs.readFileSync.returns(
       JSON.stringify({
         actions: [mockAction],
-      }),
+      })
     );
 
     const result = getEntityFromManifest('actions');
@@ -159,7 +169,7 @@ describe('get actions from manifest', () => {
     fs.readFileSync.returns(
       JSON.stringify({
         actions: [actionMock],
-      }),
+      })
     );
 
     const result = getEntityFromManifest('actions');
@@ -178,7 +188,7 @@ describe('get actions from manifest', () => {
             allowNetworks: ['412.1.1.1'],
           },
         ],
-      }),
+      })
     );
 
     getEntityFromManifest('actions');
@@ -206,7 +216,7 @@ describe('get functions from manifest', () => {
     path: 'functions/mock.js',
     entryFile: './functions/mock.ts',
     allowNetworks: ['127.0.0.1', 'some.domain.tld'],
-    accepts: ["graphql.field.mapping", "graphql.query", 'appevent.filter']
+    accepts: ['graphql.field.mapping', 'graphql.query', 'appevent.filter'],
   };
   // eslint-disable-next-line no-unused-vars
   const { entryFile: _, ...resultMock } = functionMock;
@@ -252,7 +262,7 @@ describe('get functions from manifest', () => {
     fs.readFileSync.returns(
       JSON.stringify({
         functions: [functionMock],
-      }),
+      })
     );
 
     const result = getEntityFromManifest('functions');
@@ -272,7 +282,7 @@ describe('get functions from manifest', () => {
     fs.readFileSync.returns(
       JSON.stringify({
         functions: [mockFn],
-      }),
+      })
     );
 
     const result = getEntityFromManifest('functions');
@@ -286,7 +296,7 @@ describe('get functions from manifest', () => {
     fs.readFileSync.returns(
       JSON.stringify({
         functions: [functionMock],
-      }),
+      })
     );
 
     const result = getEntityFromManifest('functions');
@@ -305,7 +315,7 @@ describe('get functions from manifest', () => {
             allowNetworks: ['412.1.1.1'],
           },
         ],
-      }),
+      })
     );
 
     getEntityFromManifest('functions');
@@ -324,7 +334,7 @@ describe('get functions from manifest', () => {
             accepts: ['webhooks.rest'],
           },
         ],
-      }),
+      })
     );
 
     getEntityFromManifest('functions');

--- a/packages/contentful--app-scripts/src/utils.ts
+++ b/packages/contentful--app-scripts/src/utils.ts
@@ -28,8 +28,16 @@ export const throwValidationException = (subject: string, message?: string, deta
 };
 
 export const isValidNetwork = (address: string) => {
-  const addressRegex =
-    /^(?:localhost|(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,6}|(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|(\[(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\]|(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}))(?::\d{1,5})?$/;
+  const addressRegex = new RegExp(
+    '^(?:' +
+      '(?:' +
+      '(?:\\*\\.)?(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,6}' +
+      '|\\*\\.[a-zA-Z]{2,6}' + // Matches wildcard domains like *.com
+      ')|' +
+      '(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|' +
+      '(\\[(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\\]|(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4})' +
+      ')(?::\\d{1,5})?$'
+  );
   return addressRegex.test(address);
 };
 


### PR DESCRIPTION
[Ticket](https://contentful.atlassian.net/browse/MONET-2345)

We already support wildcard in allow networks Cloudflare. This PR allows users using this feature while creating an app with functions that has `allowNetworks` attribute. 

We update the regex that we use to validate networks. 
