### PR TITLE
feat: support setting navigationItem for page in create-app-definition [EXT-5884]

### DIFF
--- a/packages/contentful--app-scripts/src/create-app-definition/build-app-definition-settings.test.ts
+++ b/packages/contentful--app-scripts/src/create-app-definition/build-app-definition-settings.test.ts
@@ -1,0 +1,80 @@
+import sinon from 'sinon';
+import inquirer from 'inquirer';
+import { buildAppDefinitionSettings } from './build-app-definition-settings';
+import { DEFAULT_CONTENTFUL_API_HOST } from '../constants';
+
+describe('buildAppDefinitionSettings', async () => {
+  let chai: Chai.ChaiStatic;
+  let promptStub: sinon.SinonStub;
+
+  beforeEach(async () => {
+    promptStub = sinon.stub(inquirer, 'prompt');
+    chai = await import('chai');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should add app definition settings correctly', async () => {
+    promptStub.onCall(0).resolves({
+      name: 'My custom app',
+      locations: ['app-config'],
+      host: DEFAULT_CONTENTFUL_API_HOST,
+      buildAppParameters: false,
+    });
+
+    const appDefinitionSettings = await buildAppDefinitionSettings();
+
+    chai.expect(appDefinitionSettings).to.deep.equal({
+      name: 'My custom app',
+      locations: ['dialog', 'app-config'],
+      host: DEFAULT_CONTENTFUL_API_HOST,
+      buildAppParameters: false,
+    });
+  });
+
+  it('should handle entry-field and field type selection correctly', async () => {
+    promptStub.onCall(0).resolves({
+      name: 'My custom app',
+      locations: ['entry-field'],
+      host: DEFAULT_CONTENTFUL_API_HOST,
+      buildAppParameters: false,
+      fields: [{ type: 'Symbol' }],
+    });
+
+    const appDefinitionSettings = await buildAppDefinitionSettings();
+
+    chai.expect(appDefinitionSettings).to.deep.equal({
+      name: 'My custom app',
+      locations: ['dialog', 'entry-field'],
+      host: DEFAULT_CONTENTFUL_API_HOST,
+      buildAppParameters: false,
+      fields: [{ type: 'Symbol' }],
+    });
+  });
+
+  it('should handle page and pageNav selection correctly', async () => {
+    promptStub.onCall(0).resolves({
+      name: 'My custom app',
+      locations: ['page'],
+      host: DEFAULT_CONTENTFUL_API_HOST,
+      buildAppParameters: false,
+      pageNav: true,
+      pageNavLinkName: 'My custom link',
+      pageNavLinkPath: '/my-custom-link',
+    });
+
+    const appDefinitionSettings = await buildAppDefinitionSettings();
+
+    chai.expect(appDefinitionSettings).to.deep.equal({
+      name: 'My custom app',
+      locations: ['dialog', 'page'],
+      host: DEFAULT_CONTENTFUL_API_HOST,
+      buildAppParameters: false,
+      pageNav: true,
+      pageNavLinkName: 'My custom link',
+      pageNavLinkPath: '/my-custom-link',
+    });
+  });
+});

--- a/packages/contentful--app-scripts/src/create-app-definition/build-app-definition-settings.ts
+++ b/packages/contentful--app-scripts/src/create-app-definition/build-app-definition-settings.ts
@@ -87,8 +87,8 @@ NOTE: This will create an app definition in your Contentful organization.
       when(answers) {
         return answers.locations.includes('entry-field');
       },
-      validate(answers) {
-        if (answers.length < 1) {
+      validate(input) {
+        if (input.length < 1) {
           return 'You must choose at least one field type.';
         }
         return true;
@@ -107,13 +107,10 @@ NOTE: This will create an app definition in your Contentful organization.
       name: 'pageNavLinkName',
       message: 'Page location: Provide a name for the link in the main navigation:',
       when(answers) {
-        if (answers.locations.includes('page') && answers.pageNav) {
-          return answers.name;
-        }
-        return false;
+        return answers.locations.includes('page') && answers.pageNav;
       },
-      validate(answers) {
-        if (answers.length < 1 || answers.length > 40) {
+      validate(input) {
+        if (input.length < 1 || input.length > 40) {
           return 'Size must be at least 1 and at most 40';
         }
         return true;
@@ -127,14 +124,14 @@ NOTE: This will create an app definition in your Contentful organization.
       when(answers) {
         return answers.locations.includes('page') && answers.pageNav;
       },
-      validate(answers) {
-        if (answers.length > 512) {
+      validate(input) {
+        if (input.length > 512) {
           return 'Maximum 512 characters';
         }
-        if (answers.includes(' ')) {
+        if (input.includes(' ')) {
           return 'Path cannot contain empty space';
         }
-        if (!answers.startsWith('/')) {
+        if (!input.startsWith('/')) {
           return 'Path must start with /';
         }
         return true;

--- a/packages/contentful--app-scripts/src/create-app-definition/create-app-definition.ts
+++ b/packages/contentful--app-scripts/src/create-app-definition/create-app-definition.ts
@@ -56,7 +56,10 @@ function assertValidArguments(accessToken: string, appDefinitionSettings: AppDef
   }
 }
 
-export async function createAppDefinition(accessToken: string, appDefinitionSettings: AppDefinitionSettings) {
+export async function createAppDefinition(
+  accessToken: string,
+  appDefinitionSettings: AppDefinitionSettings
+) {
   assertValidArguments(accessToken, appDefinitionSettings);
 
   const client = createClient({ accessToken, host: appDefinitionSettings.host });
@@ -78,6 +81,22 @@ export async function createAppDefinition(accessToken: string, appDefinitionSett
         return {
           location,
           fieldTypes: appDefinitionSettings.fields || [],
+        };
+      }
+
+      if (location === 'page') {
+        const { pageNav, pageNavLinkName, pageNavLinkPath } = appDefinitionSettings;
+
+        return {
+          location,
+          ...(pageNav
+            ? {
+                navigationItem: {
+                  name: pageNavLinkName,
+                  path: pageNavLinkPath,
+                },
+              }
+            : {}),
         };
       }
 
@@ -103,9 +122,9 @@ export async function createAppDefinition(accessToken: string, appDefinitionSett
     });
 
     console.log(`
-  ${chalk.greenBright('Success!')} Created an app definition for ${chalk.bold(appName)} in ${chalk.bold(
-      selectedOrg.name
-    )}.
+  ${chalk.greenBright('Success!')} Created an app definition for ${chalk.bold(
+      appName
+    )} in ${chalk.bold(selectedOrg.name)}.
 
   ${chalk.dim(`NOTE: You can update this app definition in your organization settings:
         ${chalk.underline(`https://app.contentful.com/deeplink?link=org`)}`)}


### PR DESCRIPTION
When creating an app definition and having the page location selected, you can pass an optional `navigationItem` property which determines whether the page app should appear in the apps dropdown menu and what the name and path for that link should be. This is supported in the Contentful web app when creating and editing an app definition, but it is not supported in our `Create App Definition` script as part of the `@contentful/app-scripts` package. This PR adds this functionality to this script.

I have tested this locally and can confirm that the prompts appear correctly when the page location is selected and that the validations provide warnings correctly. The validations for the link name and path are using the same validations on the input fields in the web app.

Here is the experience in the web app:
<img width="1249" alt="Screenshot 2024-10-28 at 2 30 49 PM" src="https://github.com/user-attachments/assets/429e2c16-25ae-4f85-8a0c-45d7475bd287">

Here is what the new prompts look like when using the `Create App Definition` script:
![Screenshot 2024-10-28 at 2 24 44 PM](https://github.com/user-attachments/assets/ac68bca0-8251-45af-9ec3-88e36039c103)

