### PR TITLE
chore: migrate to new segment analytics-node package [EXT-5924]

### DIFF
--- a/packages/contentful--create-contentful-app/package-lock.json
+++ b/packages/contentful--create-contentful-app/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@contentful/app-scripts": "1.27.0",
-        "analytics-node": "^6.2.0",
+        "@segment/analytics-node": "^2.2.0",
         "chalk": "4.1.2",
         "commander": "12.1.0",
         "inquirer": "8.2.6",
@@ -239,6 +239,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
       "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -247,6 +248,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
       "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
+      "license": "MIT",
       "dependencies": {
         "@lukeed/csprng": "^1.1.0"
       },
@@ -264,13 +266,14 @@
       }
     },
     "node_modules/@segment/analytics-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.6.0.tgz",
-      "integrity": "sha512-bn9X++IScUfpT7aJGjKU/yJAu/Ko2sYD6HsKA70Z2560E89x30pqgqboVKY8kootvQnT4UKCJiUr5NDMgjmWdQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.8.0.tgz",
+      "integrity": "sha512-6CrccsYRY33I3mONN2ZW8SdBpbLtu1Ict3xR+n0FemYF5RB/jG7pW6jOvDXULR8kuYMzMmGOP4HvlyUmf3qLpg==",
+      "license": "MIT",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "@segment/analytics-generic-utils": "1.2.0",
-        "dset": "^3.1.2",
+        "dset": "^3.1.4",
         "tslib": "^2.4.1"
       }
     },
@@ -278,17 +281,19 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
       "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.1"
       }
     },
     "node_modules/@segment/analytics-node": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-2.1.2.tgz",
-      "integrity": "sha512-CIqWH5G0pB/LAFAZEZtntAxujiYIpdk0F+YGhfM6N/qt4/VLWjFcd4VZXVLW7xqaxig64UKWGQhe8bszXDRXXw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-2.2.0.tgz",
+      "integrity": "sha512-mPFTSBr9CrkFBdgr7KU/YD8V/25P8vPb/hVvVHYKwEdHRovlizZ34ENgQlvqeRuamQiXD3RLM8pcWX+WxPz3lQ==",
+      "license": "MIT",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-core": "1.6.0",
+        "@segment/analytics-core": "1.8.0",
         "@segment/analytics-generic-utils": "1.2.0",
         "buffer": "^6.0.3",
         "jose": "^5.1.0",
@@ -297,15 +302,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@segment/loosely-validate-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
-      "dependencies": {
-        "component-type": "^1.2.1",
-        "join-component": "^1.1.0"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -555,24 +551,6 @@
         "node": ">= 6.0.0"
       }
     },
-    "node_modules/analytics-node": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.2.0.tgz",
-      "integrity": "sha512-NLU4tCHlWt0tzEaFQL7NIoWhq2KmQSmz0JvyS2lYn6fc4fEjTMSabhJUx8H1r5995FX8fE3rZ15uIHU6u+ovlQ==",
-      "dependencies": {
-        "@segment/loosely-validate-event": "^2.0.0",
-        "axios": "^0.27.2",
-        "axios-retry": "3.2.0",
-        "lodash.isstring": "^4.0.1",
-        "md5": "^2.2.1",
-        "ms": "^2.0.0",
-        "remove-trailing-slash": "^0.1.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -666,23 +644,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
-    "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
-      "integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
-      "dependencies": {
-        "is-retry-allowed": "^1.1.0"
-      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -896,14 +857,6 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/check-error": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
@@ -1057,14 +1010,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/component-type": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.2.tgz",
-      "integrity": "sha512-99VUHREHiN5cLeHm3YLq312p6v+HUEcwtLCAtelvUDI6+SH5g5Cr85oNR2S1o6ywzL0ykMbuwLzM2ANocjEOIA==",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1133,14 +1078,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -1255,6 +1192,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
       "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -1765,11 +1703,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -1838,14 +1771,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -1889,11 +1814,6 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
-    },
-    "node_modules/join-component": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
-      "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ=="
     },
     "node_modules/jose": {
       "version": "5.2.4",
@@ -1997,16 +1917,6 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
     },
     "node_modules/merge-options": {
       "version": "3.0.4",
@@ -2173,7 +2083,8 @@
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -2468,11 +2379,6 @@
       "engines": {
         "node": ">=8.10.0"
       }
-    },
-    "node_modules/remove-trailing-slash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
-      "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -3019,14 +2925,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/packages/contentful--create-contentful-app/package.json
+++ b/packages/contentful--create-contentful-app/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@contentful/app-scripts": "1.27.0",
-    "analytics-node": "^6.2.0",
+    "@segment/analytics-node": "^2.2.0",
     "chalk": "4.1.2",
     "commander": "12.1.0",
     "inquirer": "8.2.6",

--- a/packages/contentful--create-contentful-app/src/analytics.ts
+++ b/packages/contentful--create-contentful-app/src/analytics.ts
@@ -1,4 +1,4 @@
-import Analytics from 'analytics-node';
+import { Analytics } from '@segment/analytics-node';
 
 // Public write key scoped to data source
 const SEGMENT_WRITE_KEY = 'IzCq3j4dQlTAgLdMykRW9oBHQKUy1xMm';
@@ -15,16 +15,15 @@ export function track(properties: CCAEventProperties) {
   }
 
   try {
-    const client = new Analytics(SEGMENT_WRITE_KEY, {
-      errorHandler: () => {
-        // noop
-      },
+    const client = new Analytics({ writeKey: SEGMENT_WRITE_KEY });
+    client.on('error', () => {
+      // noop
     });
     client.track({
       event: 'app-cli-cca-creation',
       properties,
       timestamp: new Date(),
-      anonymousId: Date.now(), // generate a random id
+      anonymousId: Date.now().toString(), // generate a random id
     });
     // eslint-disable-next-line no-empty
   } catch (e) {


### PR DESCRIPTION
create-contentful-app was using a legacy version of the segment analytics node.js package. This PR removes the old package, adds the new one, and makes minor changes according to [this migration guide](https://segment.com/docs/connections/sources/catalog/libraries/server/node/migration/). 

Also see [this PR](https://github.com/contentful/create-contentful-app/pull/1774) for reference, that did the same conversion in the app-scripts package.

This should resolve alert [#107](https://github.com/contentful/create-contentful-app/security/dependabot/107)