### PR TITLE
fix: suppress warnings in CCA []

### DIFF
--- a/packages/create-contentful-app/index.js
+++ b/packages/create-contentful-app/index.js
@@ -4,4 +4,9 @@
 // It allows you to run `npx create-contentful-app` directly,
 // instead of `npx @contentful/create-contentful-app`.
 
+// The following warning is emitted from eslint: [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
+// eslint has a dependency on ajv v6, which is where this punycode deprecation warning is coming from
+// this warning is visible to users when running the create-contentful-app command on node v22, so we are suppressing warnings here until dependencies are updated
+process.removeAllListeners('warning');
+
 import '@contentful/create-contentful-app';


### PR DESCRIPTION
When using create-contentful-app with node v22, users were seeing a deprecation warning after running `npx create-contentful-app@latest`: 

```
$ npx create-contentful-app@latest
? App name (contentful-app) (node:39520) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
```

This deprecation warning is coming from ajv, which is a dependency from eslint. It seems like there is no direct solution for this at the moment, other than suggesting to use node v20 to suppress the warning. 
https://github.com/eslint/eslint/issues/17720
https://github.com/eslint/eslint/issues/17733#issuecomment-2277264699

In the meantime until this is resolved, this PR suppresses warnings so that this is no longer visible to users using node v22 with CCA.