### PR TITLE
chore: bump contentful-scoped CCA in CCA package [EXT-5924]

### DIFF
--- a/packages/create-contentful-app/package-lock.json
+++ b/packages/create-contentful-app/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.21",
       "license": "MIT",
       "dependencies": {
-        "@contentful/create-contentful-app": "1.16.14"
+        "@contentful/create-contentful-app": "1.16.19"
       },
       "bin": {
         "create-contentful-app": "index.js"
@@ -20,19 +20,19 @@
       }
     },
     "node_modules/@contentful/app-scripts": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.27.0.tgz",
-      "integrity": "sha512-iZrm5RhxJCYhuX7sEjvnPZReuIFjRSM7bCCEaLz5Jb/9y8pSBSQXYEEiOAG/94QWfxrrZ7AJ07K3LXcanorcag==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@contentful/app-scripts/-/app-scripts-1.30.1.tgz",
+      "integrity": "sha512-4Mhe8vys2TmxKL/dWLN0CDoDcehjfogAs4MVUPdL4iNSthk0s9VrJiBYn0S4XHiI/18pGy251X4Q70f0Qd0tvQ==",
       "license": "MIT",
       "dependencies": {
         "@segment/analytics-node": "^2.0.0",
-        "adm-zip": "0.5.15",
+        "adm-zip": "0.5.16",
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
         "commander": "12.1.0",
-        "contentful-management": "11.31.9",
+        "contentful-management": "11.36.1",
         "dotenv": "16.4.5",
-        "ignore": "5.3.2",
+        "ignore": "6.0.2",
         "inquirer": "8.2.6",
         "lodash": "4.17.21",
         "open": "8.4.2",
@@ -47,13 +47,13 @@
       }
     },
     "node_modules/@contentful/create-contentful-app": {
-      "version": "1.16.14",
-      "resolved": "https://registry.npmjs.org/@contentful/create-contentful-app/-/create-contentful-app-1.16.14.tgz",
-      "integrity": "sha512-3uzXel1mBJKc4kaINhDpRYdypbhM7axiUv5ZXthJZBRayVDJ1T34S+gkANiHBiMqegSLcZPBsYiQo5YzcdkL0g==",
+      "version": "1.16.19",
+      "resolved": "https://registry.npmjs.org/@contentful/create-contentful-app/-/create-contentful-app-1.16.19.tgz",
+      "integrity": "sha512-iSE7ijoSB24oUlFOuhV5PtubLy2AzRG56029lbt99nhFegdhhWFnFArvU/suieJDxdmu29f4WSXOfDtpNdJ70A==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/app-scripts": "1.27.0",
-        "analytics-node": "^6.2.0",
+        "@contentful/app-scripts": "1.30.1",
+        "@segment/analytics-node": "^2.2.0",
         "chalk": "4.1.2",
         "commander": "12.1.0",
         "inquirer": "8.2.6",
@@ -247,19 +247,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/@segment/loosely-validate-event": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-      "integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
-      "dependencies": {
-        "component-type": "^1.2.1",
-        "join-component": "^1.1.0"
-      }
-    },
     "node_modules/adm-zip": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.15.tgz",
-      "integrity": "sha512-jYPWSeOA8EFoZnucrKCNihqBjoEGQSU4HKgHYQgKNEQ0pQF9a/DYuo/+fAxY76k4qe75LUlLWpAM1QWcBMTOKw==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
@@ -275,25 +266,6 @@
       },
       "engines": {
         "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/analytics-node": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-6.2.0.tgz",
-      "integrity": "sha512-NLU4tCHlWt0tzEaFQL7NIoWhq2KmQSmz0JvyS2lYn6fc4fEjTMSabhJUx8H1r5995FX8fE3rZ15uIHU6u+ovlQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@segment/loosely-validate-event": "^2.0.0",
-        "axios": "^0.27.2",
-        "axios-retry": "3.2.0",
-        "lodash.isstring": "^4.0.1",
-        "md5": "^2.2.1",
-        "ms": "^2.0.0",
-        "remove-trailing-slash": "^0.1.0",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/ansi-colors": {
@@ -351,22 +323,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/axios-retry": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
-      "integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "is-retry-allowed": "^1.1.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -510,15 +474,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "license": "MIT"
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/chownr": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
@@ -615,15 +570,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/component-type": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.2.tgz",
-      "integrity": "sha512-99VUHREHiN5cLeHm3YLq312p6v+HUEcwtLCAtelvUDI6+SH5g5Cr85oNR2S1o6ywzL0ykMbuwLzM2ANocjEOIA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -631,9 +577,9 @@
       "license": "MIT"
     },
     "node_modules/contentful-management": {
-      "version": "11.31.9",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.31.9.tgz",
-      "integrity": "sha512-VouI9AFWxmYSdUcC8Io9mRQ4jiN/ejuw1dcv3qq9SBbz3uTddoxv6B6df/TQWToPQMM40YimafQQ/T32+6GGNQ==",
+      "version": "11.36.1",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.36.1.tgz",
+      "integrity": "sha512-mgb1vwG6tQWE/mPQTFzm9fmKLSO4N4FO8epQkfm+6EgpR5byBpDSkveOy77MPyhDFE8jJG8iwTYsS6oINbu+VA==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
@@ -643,17 +589,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/contentful-management/node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/contentful-sdk-core": {
@@ -689,15 +624,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/debug": {
@@ -923,9 +849,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -1167,9 +1093,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-6.0.2.tgz",
+      "integrity": "sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==",
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -1218,12 +1144,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "license": "MIT"
-    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -1264,15 +1184,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -1320,16 +1231,10 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/join-component": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
-      "integrity": "sha512-bF7vcQxbODoGK1imE2P9GS9aw4zD0Sd+Hni68IMZLj7zRnquH7dXUmMw9hDI5S/Jzt7q+IyTXN0rSg2GI0IKhQ==",
-      "license": "MIT"
-    },
     "node_modules/jose": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.3.tgz",
-      "integrity": "sha512-egLIoYSpcd+QUF+UHgobt5YzI2Pkw/H39ou9suW687MY6PmCwPmkNV/4TNjn1p2tX5xO3j0d0sq5hiYE24bSlg==",
+      "version": "5.9.6",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.9.6.tgz",
+      "integrity": "sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -1386,17 +1291,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
-    },
-    "node_modules/md5": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "~1.1.6"
-      }
     },
     "node_modules/merge-options": {
       "version": "3.0.4",
@@ -1543,9 +1437,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
-      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1713,12 +1607,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/remove-trailing-slash": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz",
-      "integrity": "sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==",
-      "license": "MIT"
     },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
@@ -2085,9 +1973,9 @@
       "license": "MIT"
     },
     "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/type-fest": {
@@ -2116,15 +2004,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/validate-npm-package-name": {
       "version": "5.0.1",

--- a/packages/create-contentful-app/package.json
+++ b/packages/create-contentful-app/package.json
@@ -29,7 +29,7 @@
     "create-contentful-app": "index.js"
   },
   "dependencies": {
-    "@contentful/create-contentful-app": "1.16.14"
+    "@contentful/create-contentful-app": "1.16.19"
   },
   "bugs": {
     "url": "https://github.com/contentful/create-contentful-app/issues"


### PR DESCRIPTION
Update the `@contentful/create-contentful-app` package in the `create-contentful-app` package to utilize the most recent version. Will resolve this security alert: https://github.com/contentful/create-contentful-app/security/dependabot/107

Also run `npm audit fix` to bump cross-spawn. Change is similar to [this PR](https://github.com/contentful/create-contentful-app/pull/2215/files) and [this PR](https://github.com/contentful/create-contentful-app/pull/2216), which resolves [dependabot security alert](https://github.com/advisories/GHSA-3xgq-45jj-v275) on cross-spawn.