### PR TITLE
fix: improve error handling for invalid templates in CCA [EXT-4028]

### DIFF
--- a/packages/contentful--create-contentful-app/src/constants.ts
+++ b/packages/contentful--create-contentful-app/src/constants.ts
@@ -1,6 +1,8 @@
 export const CREATE_APP_DEFINITION_GUIDE_URL =
   'https://ctfl.io/app-tutorial#embed-your-app-in-the-contentful-web-app';
 export const EXAMPLES_REPO_URL = 'https://github.com/contentful/apps/tree/master/examples';
+// These are the examples that are listed as templates instead of examples
+// OR should otherwise not be included in the list of examples displayed in the interactive mode
 export const IGNORED_EXAMPLE_FOLDERS = [
   'javascript',
   'typescript',

--- a/packages/contentful--create-contentful-app/src/getGithubFolderNames.ts
+++ b/packages/contentful--create-contentful-app/src/getGithubFolderNames.ts
@@ -1,0 +1,33 @@
+import fetch from 'node-fetch';
+import { HTTPResponseError } from './types';
+import chalk from 'chalk';
+
+interface ContentResponse {
+  type: string;
+  name: string;
+}
+
+export const CONTENTFUL_APPS_EXAMPLE_FOLDER =
+  'https://api.github.com/repos/contentful/apps/contents/examples';
+
+export async function getGithubFolderNames(): Promise<string[]> {
+  try {
+    const response = await fetch(CONTENTFUL_APPS_EXAMPLE_FOLDER);
+    if (!response.ok) {
+      throw new HTTPResponseError(
+        `${chalk.red('Error:')} Failed to fetch Contentful app templates: ${response.status} ${
+          response.statusText
+        }`
+      );
+    }
+    const contents = await response.json();
+    const filteredContents = contents.filter((content: ContentResponse) => content.type === 'dir');
+    return filteredContents.map((content: ContentResponse) => content.name);
+  } catch (err) {
+    if (err instanceof HTTPResponseError) {
+      throw err;
+    } else {
+      throw new Error(`Failed to fetch Contentful app templates: ${err}`);
+    }
+  }
+}

--- a/packages/contentful--create-contentful-app/src/index.ts
+++ b/packages/contentful--create-contentful-app/src/index.ts
@@ -162,7 +162,7 @@ async function initProject(appName: string, options: CLIOptions) {
     }
     successMessage(fullAppFolder, useYarn);
   } catch (err) {
-    error(`Failed to create ${appName}`, err);
+    error(`Failed to create ${highlight(chalk.cyan(appName))}`, err);
     process.exit(1);
   }
 }

--- a/packages/contentful--create-contentful-app/src/logger.ts
+++ b/packages/contentful--create-contentful-app/src/logger.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { HTTPResponseError, InvalidTemplateError } from './types';
 
 export function warn(message: string): void {
   console.log(`${chalk.yellow('Warning:')} ${message}`);
@@ -8,6 +9,10 @@ export function error(message: string, error: unknown): void {
   console.log(`${chalk.red('Error:')} ${message}`);
   if (error === undefined) {
     return;
+  } else if (error instanceof InvalidTemplateError || error instanceof HTTPResponseError) {
+    // for known errors, we just want to show the message
+    console.log();
+    console.log(error.message);
   } else if (error instanceof Error) {
     console.log();
     console.log(error);
@@ -21,9 +26,9 @@ export function error(message: string, error: unknown): void {
 }
 
 export function wrapInBlanks(message: string | chalk.Chalk) {
-  console.log(' ')
-  console.log(message)
-  console.log(' ')
+  console.log(' ');
+  console.log(message);
+  console.log(' ');
 }
 
 export function highlight(str: string) {

--- a/packages/contentful--create-contentful-app/src/template.ts
+++ b/packages/contentful--create-contentful-app/src/template.ts
@@ -42,7 +42,6 @@ function cleanUp(destination: string) {
 
 export async function cloneTemplateIn(destination: string, source: string) {
   await clone(source, destination);
-  console.log(success('Done!'));
 
   try {
     validate(destination);
@@ -53,4 +52,5 @@ export async function cloneTemplateIn(destination: string, source: string) {
   }
 
   cleanUp(destination);
+  console.log(success('Done!'));
 }

--- a/packages/contentful--create-contentful-app/src/types.ts
+++ b/packages/contentful--create-contentful-app/src/types.ts
@@ -13,3 +13,6 @@ export const ContentfulExample = {
   Javascript: 'javascript',
   Typescript: 'typescript',
 };
+
+export class InvalidTemplateError extends Error {}
+export class HTTPResponseError extends Error {}

--- a/packages/contentful--create-contentful-app/test/getGithubFolderNames.spec.ts
+++ b/packages/contentful--create-contentful-app/test/getGithubFolderNames.spec.ts
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import * as nodeFetch from 'node-fetch';
+import sinon from 'sinon';
+import { getGithubFolderNames } from '../src/getGithubFolderNames';
+
+describe('getGithubFolderNames', () => {
+  let stubbedFetch: sinon.SinonStub;
+  const responseBody = [
+    { name: 'page-location', path: 'examples/page-location', type: 'dir' },
+    { name: 'home-location', path: 'examples/home-location', type: 'dir' },
+  ];
+  const responseSuccessInit = {
+    status: 200,
+    statusText: 'OK',
+    headers: { 'content-type': 'application/json' },
+  };
+
+  const responseFailureInit = {
+    status: 404,
+    statusText: 'Not Found',
+    headers: { 'content-type': 'application/json' },
+  };
+
+  beforeEach(() => {
+    stubbedFetch = sinon.stub(nodeFetch, 'default');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('returns the folder result when fetch is successful', async () => {
+    stubbedFetch.resolves(
+      new nodeFetch.Response(JSON.stringify(responseBody), responseSuccessInit)
+    );
+    const folders = await getGithubFolderNames();
+    expect(folders).to.have.lengthOf(2);
+  });
+
+  it('should throw an error when fetch fails', async () => {
+    stubbedFetch.rejects(new nodeFetch.Response(JSON.stringify({}), responseFailureInit));
+    try {
+      await getGithubFolderNames();
+    } catch (error) {
+      expect(error).to.be.an('error');
+      expect(error.message).to.contain('Failed to fetch Contentful app templates:');
+    }
+  });
+});

--- a/packages/contentful--create-contentful-app/test/getTemplateSource.spec.ts
+++ b/packages/contentful--create-contentful-app/test/getTemplateSource.spec.ts
@@ -1,0 +1,93 @@
+import { expect } from 'chai';
+import inquirer from 'inquirer';
+import sinon from 'sinon';
+import { EXAMPLES_PATH } from '../src/constants';
+import * as getGithubFolderNamesModule from '../src/getGithubFolderNames';
+import { getTemplateSource, makeContentfulExampleSource } from '../src/getTemplateSource';
+import { ContentfulExample, InvalidTemplateError } from '../src/types';
+
+describe('getTemplateSource', () => {
+  describe('makeContentfulExampleSource', () => {
+    let getGithubFolderNamesStub;
+    let promptStub;
+
+    beforeEach(() => {
+      getGithubFolderNamesStub = sinon.stub(getGithubFolderNamesModule, 'getGithubFolderNames');
+      promptStub = sinon.stub(inquirer, 'prompt');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should return template source with valid example template', async () => {
+      getGithubFolderNamesStub.resolves(['home-location', 'page-location']);
+
+      const templateSource = await makeContentfulExampleSource({ example: 'home-location' });
+      expect(templateSource).to.equal(`${EXAMPLES_PATH}home-location`);
+    });
+
+    it('should throw an error with invalid example template', async () => {
+      getGithubFolderNamesStub.resolves(['home-location', 'page-location']);
+
+      try {
+        const templateSource = await makeContentfulExampleSource({ example: 'invalid' });
+        console.log(templateSource);
+      } catch (error) {
+        expect(error instanceof InvalidTemplateError).to.be.true;
+      }
+    });
+
+    it('should return template source with valid javascript template option', async () => {
+      const templateSource = await makeContentfulExampleSource({ javascript: true });
+      expect(templateSource).to.equal(`${EXAMPLES_PATH}${ContentfulExample.Javascript}`);
+    });
+
+    it('should return template source with valid typescript template option', async () => {
+      const templateSource = await makeContentfulExampleSource({ typescript: true });
+      expect(templateSource).to.equal(`${EXAMPLES_PATH}${ContentfulExample.Typescript}`);
+    });
+
+    it('should return typescript template source with function option', async () => {
+      const templateSource = await makeContentfulExampleSource({ function: 'function-appaction' });
+      expect(templateSource).to.equal(`${EXAMPLES_PATH}${ContentfulExample.Typescript}`);
+    });
+
+    it('should return typescript template source with action option', async () => {
+      const templateSource = await makeContentfulExampleSource({ function: true });
+      expect(templateSource).to.equal(`${EXAMPLES_PATH}${ContentfulExample.Typescript}`);
+    });
+
+    it('should return prompt example selection if no options are provided', async () => {
+      promptStub.resolves({ starter: 'template', language: 'vite-react' });
+      const templateSource = await makeContentfulExampleSource({});
+      expect(templateSource).to.equal(`${EXAMPLES_PATH}vite-react`);
+    });
+  });
+
+  describe('getTemplateSource', async () => {
+    let consoleLogSpy;
+
+    beforeEach(() => {
+      consoleLogSpy = sinon.spy(console, 'log');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should return source without a warning when it is a Contentful template', async () => {
+      const source = `${EXAMPLES_PATH}${ContentfulExample.Typescript}`;
+      const sourceResult = await getTemplateSource({ source });
+      expect(sourceResult).to.equal(source);
+      expect(consoleLogSpy.calledOnce).to.be.false;
+    });
+
+    it('should provide warning if source is not a Contentful template', async () => {
+      const source = 'my-source';
+      const sourceResult = await getTemplateSource({ source });
+      expect(sourceResult).to.equal(source);
+      expect(consoleLogSpy.getCall(0).args[0]).to.include('Warning');
+    });
+  });
+});

--- a/packages/contentful--create-contentful-app/test/includeFunction.spec.ts
+++ b/packages/contentful--create-contentful-app/test/includeFunction.spec.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import { rimraf } from 'rimraf';
+import sinon from 'sinon';
+import { functionTemplateFromName } from '../src/includeFunction';
+
+describe('includeFunction', () => {
+  describe('functionTemplateFromName', () => {
+    let stubbedRimraf: sinon.SinonStub;
+    beforeEach(() => {
+      stubbedRimraf = sinon.stub(rimraf, 'sync');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should return the correct function template when given a valid template name', () => {
+      const functionTemplate = functionTemplateFromName(
+        'appevent-filter',
+        '/Users/person/dev/my-app'
+      );
+      expect(functionTemplate).to.equal('appevent-filter');
+    });
+
+    it('should return the correct function template when given the legacy external-references name', () => {
+      const functionTemplate = functionTemplateFromName(
+        'external-references',
+        '/Users/person/dev/my-app'
+      );
+      expect(functionTemplate).to.equal('templates');
+    });
+
+    it('should throw an error with an invalid function template name', () => {
+      try {
+        functionTemplateFromName('nope', '/Users/person/dev/my-app');
+      } catch (error) {
+        expect(error.message).to.contain('Invalid function template:');
+      }
+      sinon.assert.calledOnce(stubbedRimraf);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses several improvements to error handling for create-contentful-app:

1. **Invalid template error:** Check to see if the template name provided with the `--example` option actually exists as a valid example. If not, then display a more helpful error message directing users where they can find the list.
2. **Invalid function template error:** When the user passes an invalid function template, clean up the error message so the formatting matches the invalid template error. Also, remove the cloned typescript example that is created before the function is created if there is an error.
3. **Error fetching templates:** Add error handling for fetching the example folder names

See below for before and after for these error messages.

| Before | After |
| --- | --- |
| **Invalid Template** | **Invalid Template** |
| ![Screenshot 2025-01-02 at 8 52 32 AM](https://github.com/user-attachments/assets/69a49418-f7af-4c2f-92f8-386bf713612a)  |  ![Screenshot 2025-01-02 at 9 03 01 AM](https://github.com/user-attachments/assets/b5d923f7-d120-4989-a3a1-6f5da0bfd50d) |
| **Invalid Function Template** | **Invalid Function Template** |
|  ![Screenshot 2025-01-02 at 8 56 13 AM](https://github.com/user-attachments/assets/9a1777b1-516f-4fd5-800b-e5d3db28af6f) |  ![Screenshot 2025-01-02 at 9 03 40 AM](https://github.com/user-attachments/assets/da479eb7-74cf-4079-a5aa-2133566b7a35) |
| **Error Fetching Templates** | **Error Fetching Templates** |
|  ![Screenshot 2025-01-02 at 8 48 24 AM](https://github.com/user-attachments/assets/7c0f60e6-92c9-450d-87eb-3f04accf29c9)  |  ![Screenshot 2025-01-02 at 9 01 51 AM](https://github.com/user-attachments/assets/08ca04bb-365f-444c-90cf-9ec1f4b6442a)  |

I also added new tests for all of these methods.
