### PR TITLE
fix: only set default src when creating app def if a frontend location is specified [EXT-5935]

### DIFF
--- a/packages/contentful--app-scripts/src/create-app-definition/create-app-definition.test.ts
+++ b/packages/contentful--app-scripts/src/create-app-definition/create-app-definition.test.ts
@@ -92,4 +92,32 @@ describe('createAppDefinition', () => {
     assert(loggedMessage.includes(tutorialLink));
     assert.deepStrictEqual(cachedEnvVarsMock.args[0][0], { [APP_DEF_ENV_KEY]: 'appId' });
   });
+
+  it('sets default src if any frontend location is specified', async () => {
+    const createAppDefinitionStub = stub().resolves({ sys: { id: 'testId' } });
+    clientMock.getOrganization = stub().resolves({
+      createAppDefinition: createAppDefinitionStub,
+    });
+    clientMock.getOrganizations = stub().resolves({
+      items: [{ name: 'name', sys: { id: organizationId } }],
+    });
+    selectFromListMock.returns({ name: 'name', value: organizationId });
+
+    await subject(token, { locations: ['entry-field', 'dialog'] });
+    assert(createAppDefinitionStub.calledWithMatch({ src: 'http://localhost:3000' }));
+  });
+
+  it('does not set default src if only location is dialog', async () => {
+    const createAppDefinitionStub = stub().resolves({ sys: { id: 'testId' } });
+    clientMock.getOrganization = stub().resolves({
+      createAppDefinition: createAppDefinitionStub,
+    });
+    clientMock.getOrganizations = stub().resolves({
+      items: [{ name: 'name', sys: { id: organizationId } }],
+    });
+    selectFromListMock.returns({ name: 'name', value: organizationId });
+
+    await subject(token, { locations: ['dialog'] });
+    assert(createAppDefinitionStub.calledWithMatch({ src: undefined }));
+  });
 });

--- a/packages/contentful--app-scripts/src/create-app-definition/create-app-definition.ts
+++ b/packages/contentful--app-scripts/src/create-app-definition/create-app-definition.ts
@@ -73,37 +73,39 @@ export async function createAppDefinition(
   const organizationId = selectedOrg.value;
 
   const appName = appDefinitionSettings.name || path.basename(process.cwd());
-  const body = {
-    name: appName,
-    src: 'http://localhost:3000',
-    locations: appDefinitionSettings.locations.map((location) => {
-      if (location === 'entry-field') {
-        return {
-          location,
-          fieldTypes: appDefinitionSettings.fields || [],
-        };
-      }
+  const locations = appDefinitionSettings.locations.map((location) => {
+    if (location === 'entry-field') {
+      return {
+        location,
+        fieldTypes: appDefinitionSettings.fields || [],
+      };
+    }
 
-      if (location === 'page') {
-        const { pageNav, pageNavLinkName, pageNavLinkPath } = appDefinitionSettings;
-
-        return {
-          location,
-          ...(pageNav
-            ? {
-                navigationItem: {
-                  name: pageNavLinkName,
-                  path: pageNavLinkPath,
-                },
-              }
-            : {}),
-        };
-      }
+    if (location === 'page') {
+      const { pageNav, pageNavLinkName, pageNavLinkPath } = appDefinitionSettings;
 
       return {
         location,
+        ...(pageNav
+          ? {
+              navigationItem: {
+                name: pageNavLinkName,
+                path: pageNavLinkPath,
+              },
+            }
+          : {}),
       };
-    }),
+    }
+
+    return {
+      location,
+    };
+  })
+  const hasFrontendLocation = locations.some(({ location }) => location !== 'dialog');
+  const body = {
+    name: appName,
+    src: hasFrontendLocation ? 'http://localhost:3000' : undefined,
+    locations,
     parameters: {
       ...(appDefinitionSettings.parameters?.instance && {
         instance: appDefinitionSettings.parameters.instance,


### PR DESCRIPTION
It is now possible for apps to be "frontendless", containing only functions. As such, when creating an app definition, if no frontend locations are specified, the default "src" should be omitted.