### PR TITLE
fix: support host option for all commands [EXT-5971]

### DIFF
--- a/packages/contentful--app-scripts/README.md
+++ b/packages/contentful--app-scripts/README.md
@@ -177,6 +177,16 @@ You can also execute this command without the argument if the environment variab
 > $ CONTENTFUL_APP_DEF_ID=some-definition-id npx --no-install @contentful/app-scripts open-settings
 > ```
 
+**Options:**
+
+| Argument          | Description                                  | Default value        |
+| ----------------- | -------------------------------------------- | -------------------- |
+|                   |
+| `--definition-id` | The ID of the app to which to add the bundle |
+| `--host`          | (optional) Contentful CMA-endpoint to use    | `api.contentful.com` |
+
+**Note:** You can also pass all arguments in interactive mode to skip being asked for it.
+
 ### Clean up bundles
 
 Allows you to clean the list of previous bundles. It fetches the list and deletes all bundles except the 50 newest ones.
@@ -246,6 +256,16 @@ By default, the script will install the app into the default host URL: `app.cont
 > $ npx --no-install @contentful/app-scripts install --definition-id some-definition-id --host api.eu.contentful.com
 > ```
 
+**Options:**
+
+| Argument          | Description                                  | Default value        |
+| ----------------- | -------------------------------------------- | -------------------- |
+|                   |
+| `--definition-id` | The ID of the app to which to add the bundle |
+| `--host`          | (optional) Contentful CMA-endpoint to use    | `api.contentful.com` |
+
+**Note:** You can also pass all arguments in interactive mode to skip being asked for it.
+
 ### Tracking
 
 We gather depersonalized usage data of our CLI tools in order to improve experience. If you do not want your data to be gathered, you can opt out by providing an env variable `DISABLE_ANALYTICS` set to any value:
@@ -286,7 +306,7 @@ When passing the `--ci` argument adding all variables as arguments is required
 **Options:**
 
 Options:
-  -e, --esbuild-config <path>  custom esbuild config file path
-  -m, --manifest-file <path>   Contentful app manifest file path
-  -w, --watch                  watch for changes
-  -h, --help                   display help for command
+-e, --esbuild-config <path> custom esbuild config file path
+-m, --manifest-file <path> Contentful app manifest file path
+-w, --watch watch for changes
+-h, --help display help for command

--- a/packages/contentful--app-scripts/src/activate/build-bundle-activate-settings.ts
+++ b/packages/contentful--app-scripts/src/activate/build-bundle-activate-settings.ts
@@ -3,7 +3,7 @@ import { getAppInfo } from '../get-app-info';
 import { ActivateOptions, ActivateSettings } from '../types';
 
 export async function buildBundleActivateSettings(
-  options: ActivateOptions,
+  options: ActivateOptions
 ): Promise<ActivateSettings> {
   const { bundleId, host } = options;
   const prompts = [];
@@ -23,12 +23,13 @@ export async function buildBundleActivateSettings(
     });
   }
 
-  const appActivateSettings = await inquirer.prompt(prompts);
-  const appInfo = await getAppInfo(options);
+  const { host: interactiveHost, ...appActivateSettings } = await inquirer.prompt(prompts);
+  const hostValue = host || interactiveHost;
+  const appInfo = await getAppInfo({ ...options, host: hostValue });
 
   return {
     bundleId,
-    host,
+    host: hostValue,
     ...appActivateSettings,
     ...appInfo,
   };

--- a/packages/contentful--app-scripts/src/bin.ts
+++ b/packages/contentful--app-scripts/src/bin.ts
@@ -69,6 +69,7 @@ async function runCommand(command: Command, options?: any) {
     .command('open-settings')
     .description('Opens the app editor for a given AppDefinition')
     .option('--definition-id  [defId]', 'The id of your apps definition')
+    .option('--host [host]', 'Contentful domain to use')
     .action(async (options) => {
       await runCommand(open, options);
     });

--- a/packages/contentful--app-scripts/src/bin.ts
+++ b/packages/contentful--app-scripts/src/bin.ts
@@ -48,7 +48,7 @@ async function runCommand(command: Command, options?: any) {
     .option('--token [accessToken]', 'Your content management access token')
     .option('--comment [comment]', 'Optional comment for the created bundle')
     .option('--skip-activation', 'A Boolean flag to skip automatic activation')
-    .option('--host [host]', 'Contentful domain to use')
+    .option('--host [host]', 'Contentful subdomain to use, e.g. "api.contentful.com"')
     .action(async (options) => {
       await runCommand(upload, options);
     });
@@ -60,7 +60,7 @@ async function runCommand(command: Command, options?: any) {
     .option('--organization-id [orgId]', 'The id of your organization')
     .option('--definition-id  [defId]', 'The id of your apps definition')
     .option('--token [accessToken]', 'Your content management access token')
-    .option('--host [host]', 'Contentful domain to use')
+    .option('--host [host]', 'Contentful subdomain to use, e.g. "api.contentful.com"')
     .action(async (options) => {
       await runCommand(activate, options);
     });
@@ -69,7 +69,7 @@ async function runCommand(command: Command, options?: any) {
     .command('open-settings')
     .description('Opens the app editor for a given AppDefinition')
     .option('--definition-id  [defId]', 'The id of your apps definition')
-    .option('--host [host]', 'Contentful domain to use')
+    .option('--host [host]', 'Contentful subdomain to use, e.g. "api.contentful.com"')
     .action(async (options) => {
       await runCommand(open, options);
     });
@@ -81,7 +81,7 @@ async function runCommand(command: Command, options?: any) {
     .option('--definition-id  [defId]', 'The id of your apps definition')
     .option('--token [accessToken]', 'Your content management access token')
     .option('--keep [keepAmount]', 'The amount of bundles that should remain')
-    .option('--host [host]', 'Contentful domain to use')
+    .option('--host [host]', 'Contentful subdomain to use, e.g. "api.contentful.com"')
     .action(async (options) => {
       await runCommand(cleanup, options);
     });
@@ -99,7 +99,7 @@ async function runCommand(command: Command, options?: any) {
       'Opens a picker to select the space and environment for installing the app associated with a given AppDefinition'
     )
     .option('--definition-id  [defId]', 'The id of your apps definition')
-    .option('--host [host]', 'Contentful domain to use')
+    .option('--host [host]', 'Contentful subdomain to use, e.g. "api.contentful.com"')
     .action(async (options) => {
       await runCommand(install, options);
     });

--- a/packages/contentful--app-scripts/src/clean-up/build-clean-up-settings.ts
+++ b/packages/contentful--app-scripts/src/clean-up/build-clean-up-settings.ts
@@ -23,12 +23,13 @@ export async function buildCleanUpSettings(options: CleanupOptions): Promise<Cle
     });
   }
 
-  const appCleanUpSettings = await prompt(prompts);
-  const appInfo = await getAppInfo(options);
+  const { host: interactiveHost, ...appCleanUpSettings } = await prompt(prompts);
+  const hostValue = host || interactiveHost;
+  const appInfo = await getAppInfo({ ...options, host: hostValue });
 
   return {
     keep: keep === undefined ? +appCleanUpSettings.keep : +keep,
-    host,
+    host: hostValue,
     ...appCleanUpSettings,
     ...appInfo,
   };

--- a/packages/contentful--app-scripts/src/install/install.test.ts
+++ b/packages/contentful--app-scripts/src/install/install.test.ts
@@ -1,10 +1,13 @@
 import { SinonStub, stub } from 'sinon';
 import assert from 'assert';
-import { APP_DEF_ENV_KEY } from '../constants';
+import {
+  APP_DEF_ENV_KEY,
+  DEFAULT_CONTENTFUL_API_HOST,
+  DEFAULT_CONTENTFUL_APP_HOST,
+} from '../constants';
 import proxyquire from 'proxyquire';
 
 const TEST_DEF_ID = 'test-def-id';
-const TEST_HOST = 'test.host.com';
 
 describe('install', () => {
   let subject: typeof import('./install').installToEnvironment,
@@ -29,33 +32,40 @@ describe('install', () => {
     }));
   });
 
-  it('works with an app ID option passed', () => {
-    subject({ definitionId: TEST_DEF_ID });
+  it('works with both host and app ID options passed', async () => {
+    await subject({ host: DEFAULT_CONTENTFUL_API_HOST, definitionId: TEST_DEF_ID });
+    assert(
+      installMock.calledWith(
+        `https://${DEFAULT_CONTENTFUL_APP_HOST}/deeplink?link=apps&id=${TEST_DEF_ID}`
+      )
+    );
+  });
+
+  it('shows prompt when no options are provided', () => {
+    subject({});
+    assert.strictEqual(inquirerMock.called, true);
+  });
+
+  it('throws an error when no app definition is defined', async () => {
+    try {
+      await subject({});
+    } catch (err) {
+      assert.strictEqual(err.message, 'No app-definition-id');
+    }
+  });
+
+  it('works with env variable set', async () => {
+    process.env[APP_DEF_ENV_KEY] = TEST_DEF_ID;
+    await subject({});
     assert(
       installMock.calledWith(`https://app.contentful.com/deeplink?link=apps&id=${TEST_DEF_ID}`)
     );
   });
 
-  it('works with both host and app ID options passed', () => {
-    subject({ host: TEST_HOST, definitionId: TEST_DEF_ID });
-    assert(installMock.calledWith(`https://${TEST_HOST}/deeplink?link=apps&id=${TEST_DEF_ID}`));
-  });
-
-  it('shows prompt when no app definition is provided', () => {
-    subject({});
-    assert.strictEqual(inquirerMock.called, true);
-  });
-
-  it('shows prompt when host is provided, but no app definition', () => {
-    subject({ host: TEST_HOST });
-    assert.strictEqual(inquirerMock.called, true);
-  });
-
-  it('works with env variable set', () => {
-    process.env[APP_DEF_ENV_KEY] = TEST_DEF_ID;
-    subject({});
+  it('works with EU host option passed', async () => {
+    await subject({ definitionId: TEST_DEF_ID, host: 'api.eu.contentful.com' });
     assert(
-      installMock.calledWith(`https://app.contentful.com/deeplink?link=apps&id=${TEST_DEF_ID}`)
+      installMock.calledWith(`https://app.eu.contentful.com/deeplink?link=apps&id=${TEST_DEF_ID}`)
     );
   });
 });

--- a/packages/contentful--app-scripts/src/open/open-settings.test.ts
+++ b/packages/contentful--app-scripts/src/open/open-settings.test.ts
@@ -1,8 +1,11 @@
 import { SinonStub, stub } from 'sinon';
 import assert from 'assert';
-import { APP_DEF_ENV_KEY } from '../constants';
+import {
+  APP_DEF_ENV_KEY,
+  DEFAULT_CONTENTFUL_API_HOST,
+  DEFAULT_CONTENTFUL_APP_HOST,
+} from '../constants';
 import proxyquire from 'proxyquire';
-import { REDIRECT_URL } from './open-settings';
 
 const TEST_DEF_ID = 'test-def-id';
 
@@ -10,6 +13,7 @@ describe('openSettings', () => {
   let subject: typeof import('./open-settings').openSettings,
     openMock: SinonStub,
     inquirerMock: SinonStub;
+
   beforeEach(() => {
     delete process.env[APP_DEF_ENV_KEY];
     stub(console, 'log');
@@ -29,19 +33,44 @@ describe('openSettings', () => {
     }));
   });
 
-  it('works with option passed', () => {
-    subject({ definitionId: TEST_DEF_ID });
-    assert(openMock.calledWith(`${REDIRECT_URL}&id=${TEST_DEF_ID}`));
+  it('works with app definition id and host options passed', async () => {
+    await subject({ definitionId: TEST_DEF_ID, host: DEFAULT_CONTENTFUL_API_HOST });
+    assert(
+      openMock.calledWith(
+        `https://${DEFAULT_CONTENTFUL_APP_HOST}/deeplink?link=app-definition&id=${TEST_DEF_ID}`
+      )
+    );
   });
 
-  it('shows prompt when no definition is provided', () => {
+  it('shows prompt when no options are provided', () => {
     subject({});
     assert.strictEqual(inquirerMock.called, true);
   });
 
-  it('works with env variable set', () => {
+  it('throws an error when no app definition is defined', async () => {
+    try {
+      await subject({});
+    } catch (err) {
+      assert.strictEqual(err.message, 'No app-definition-id');
+    }
+  });
+
+  it('works with app id env variable set', async () => {
     process.env[APP_DEF_ENV_KEY] = TEST_DEF_ID;
-    subject({});
-    assert(openMock.calledWith(`${REDIRECT_URL}&id=${TEST_DEF_ID}`));
+    await subject({ host: DEFAULT_CONTENTFUL_API_HOST });
+    assert(
+      openMock.calledWith(
+        `https://${DEFAULT_CONTENTFUL_APP_HOST}/deeplink?link=app-definition&id=${TEST_DEF_ID}`
+      )
+    );
+  });
+
+  it('works with EU host option passed', async () => {
+    await subject({ definitionId: TEST_DEF_ID, host: 'api.eu.contentful.com' });
+    assert(
+      openMock.calledWith(
+        `https://app.eu.contentful.com/deeplink?link=app-definition&id=${TEST_DEF_ID}`
+      )
+    );
   });
 });

--- a/packages/contentful--app-scripts/src/types.ts
+++ b/packages/contentful--app-scripts/src/types.ts
@@ -56,6 +56,7 @@ export interface CleanupSettings {
 
 export interface OpenSettingsOptions {
   definitionId?: string;
+  host?: string;
 }
 
 export interface InstallOptions {

--- a/packages/contentful--app-scripts/src/upload/build-upload-settings.ts
+++ b/packages/contentful--app-scripts/src/upload/build-upload-settings.ts
@@ -10,7 +10,7 @@ export async function buildAppUploadSettings(options: UploadOptions): Promise<Up
   const prompts = [];
   const { bundleDir, comment, skipActivation, host } = options;
 
-  if (! bundleDir) {
+  if (!bundleDir) {
     prompts.push({
       name: 'bundleDirectory',
       message: `Bundle directory, if not default:`,
@@ -41,15 +41,15 @@ export async function buildAppUploadSettings(options: UploadOptions): Promise<Up
     });
   }
 
-  const { activateBundle, ...appUploadSettings } = await prompt(prompts);
-
-  const appInfo = await getAppInfo(options);
+  const { activateBundle, host: interactiveHost, ...appUploadSettings } = await prompt(prompts);
+  const hostValue = host || interactiveHost;
+  const appInfo = await getAppInfo({ ...options, host: hostValue });
 
   return {
     bundleDirectory: bundleDir,
     skipActivation: skipActivation === undefined ? !activateBundle : skipActivation,
     comment,
-    host,
+    host: hostValue,
     actions: actionsManifest,
     functions: functionManifest,
     ...appUploadSettings,
@@ -57,6 +57,6 @@ export async function buildAppUploadSettings(options: UploadOptions): Promise<Up
   };
 }
 
-export function hostProtocolFilter (input: string) {
+export function hostProtocolFilter(input: string) {
   return input.replace(/^https?:\/\//, '');
 }

--- a/packages/contentful--app-scripts/src/upload/create-app-bundle.ts
+++ b/packages/contentful--app-scripts/src/upload/create-app-bundle.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import ora from 'ora';
-import { showCreationError } from '../utils';
+import { getWebAppHostname, showCreationError } from '../utils';
 import { createClient } from 'contentful-management';
 
 import { createAppUpload } from './create-app-upload';
@@ -43,7 +43,7 @@ export async function createAppBundleFromSettings(settings: UploadSettings) {
 
     console.log(`
   ${chalk.yellow('Done!')} Your files were successfully uploaded and a new AppUpload (${chalk.dim(
-      appUpload.sys.id,
+      appUpload.sys.id
     )}) has been created.`);
   } catch (err: any) {
     return showCreationError('app upload', err.message);
@@ -57,11 +57,13 @@ export async function createAppBundleFromSettings(settings: UploadSettings) {
 
   console.log(`
   ${chalk.cyan('Success!')} Created a new app bundle for ${chalk.cyan(
-    settings.definition.name,
+    settings.definition.name
   )} in ${chalk.bold(settings.organization.name)}.
 
   Bundle Id: ${chalk.yellow(appBundle.sys.id)}
   `);
+
+  const webApp = getWebAppHostname(settings.host);
 
   if (settings.skipActivation) {
     console.log(`
@@ -69,7 +71,7 @@ export async function createAppBundleFromSettings(settings: UploadSettings) {
 
     ${chalk.bold('You can activate this app bundle in your apps settings:')}
 
-      ${chalk.underline('https://app.contentful.com/deeplink?link=app-definition-list')}
+      ${chalk.underline(`https://${webApp}/deeplink?link=app-definition-list`)}
 
     ${chalk.bold('or by simply running the cli command:')}
 

--- a/packages/contentful--app-scripts/src/utils.test.ts
+++ b/packages/contentful--app-scripts/src/utils.test.ts
@@ -2,7 +2,8 @@ import assert from 'assert';
 import { SinonStub, stub } from 'sinon';
 import proxyquire from 'proxyquire';
 
-import { isValidNetwork, stripProtocol } from './utils';
+import { getWebAppHostname, isValidNetwork, stripProtocol } from './utils';
+import { DEFAULT_CONTENTFUL_APP_HOST } from './constants';
 
 describe('isValidIpAddress', () => {
   it('returns true for a valid IP address', () => {
@@ -69,7 +70,6 @@ describe('isValidIpAddress', () => {
     const result = isValidNetwork('*');
     assert.strictEqual(result, false);
   });
-
 });
 
 describe('removeProtocolFromUrl', () => {
@@ -365,5 +365,22 @@ describe('get functions from manifest', () => {
     getEntityFromManifest('functions');
 
     assert.ok(exitStub.calledOnceWith(1));
+  });
+});
+
+describe('get web app hostname', () => {
+  it('should return the default if host is undefined', () => {
+    const result = getWebAppHostname(undefined);
+    assert.equal(result, DEFAULT_CONTENTFUL_APP_HOST);
+  });
+
+  it('should return the host with app subdomain', () => {
+    const result = getWebAppHostname('api.contentful.com');
+    assert.equal(result, DEFAULT_CONTENTFUL_APP_HOST);
+  });
+
+  it('should return the host with app subdomain for EU', () => {
+    const result = getWebAppHostname('api.eu.contentful.com');
+    assert.equal(result, 'app.eu.contentful.com');
   });
 });

--- a/packages/contentful--app-scripts/src/utils.ts
+++ b/packages/contentful--app-scripts/src/utils.ts
@@ -5,6 +5,7 @@ import { cacheEnvVars } from './cache-credential';
 import { Definition } from './definition-api';
 import { Organization } from './organization-api';
 import { ContentfulFunction, FunctionAppAction } from './types';
+import { DEFAULT_CONTENTFUL_APP_HOST } from './constants';
 
 const DEFAULT_MANIFEST_PATH = './contentful-app-manifest.json';
 
@@ -17,7 +18,7 @@ const functionEvents = {
   resourceTypeMappingEvent: 'graphql.resourcetype.mapping',
   queryEvent: 'graphql.query',
   resourceLinksSearchEvent: 'resources.search',
-  resourceLinksLookupEvent: 'resources.lookup'
+  resourceLinksLookupEvent: 'resources.lookup',
 };
 
 export const throwValidationException = (subject: string, message?: string, details?: string) => {
@@ -192,4 +193,8 @@ export function getEntityFromManifest<Type extends 'actions' | 'functions'>(
     // eslint-disable-next-line no-process-exit
     process.exit(1);
   }
+}
+
+export function getWebAppHostname(host: string | undefined): string {
+  return host && host.includes('api') ? host.replace('api', 'app') : DEFAULT_CONTENTFUL_APP_HOST;
 }


### PR DESCRIPTION
This PR cleans up handling the `host` option throughout our `app-scripts` package. Here are the specific updates:

- `create-app-definition`: The copy displayed after app definition creation always displayed `app.contentful.com`. Now it will display the correct webapp host based on the host option.
- `upload`: Fixes a bug in interactive mode where the provided host option was not being properly passed through and also updates the copy after success to use the correct webapp host.
- `bundle-cleanup`: Fixes a bug in interactive mode where the provided host option was not being properly passed through.
- `activate`: Fixes a bug in interactive mode where the provided host option was not being properly passed through.
- `open-settings`: Host was not provided as an option, so this adds support for it.
- `install`: Fixes a bug where host value needed to be translated to web app host.

Now users should be able to use the host option for all of these commands to set the host to `api.eu.contentful.com` for EUDR customers.
