### PR TITLE
fix: app-manifest-entry-paths-correction [NONE]

### DIFF
--- a/packages/contentful--app-scripts/src/generate-function/clone.test.ts
+++ b/packages/contentful--app-scripts/src/generate-function/clone.test.ts
@@ -66,9 +66,9 @@ describe('Helper functions tests', () => {
       // The id should be the settings.name
       assert.strictEqual(entry.id, dummySettings.name);
       // The path is updated to always have a .js extension
-      assert.strictEqual(entry.path, `./functions/${renameFile.replace('.ts', '.js')}`);
+      assert.strictEqual(entry.path, `functions/${renameFile.replace('.ts', '.js')}`);
       // entryFile remains unchanged (uses the original renameFile)
-      assert.strictEqual(entry.entryFile, `./functions/${renameFile}`);
+      assert.strictEqual(entry.entryFile, `functions/${renameFile}`);
     });
   });
 

--- a/packages/contentful--app-scripts/src/generate-function/clone.ts
+++ b/packages/contentful--app-scripts/src/generate-function/clone.ts
@@ -53,8 +53,8 @@ export async function touchupAppManifest(localPath: string, settings: GenerateFu
   const entry = appManifest["functions"][appManifest["functions"].length - 1];
   entry.id = settings.name;
   // the path always has a .js extension
-  entry.path = `./functions/${renameFunctionFile.replace('.ts', '.js')}`;
-  entry.entryFile = `./functions/${renameFunctionFile}`;
+  entry.path = `functions/${renameFunctionFile.replace('.ts', '.js')}`;
+  entry.entryFile = `functions/${renameFunctionFile}`;
   await fs.writeFileSync(`${localPath}/${CONTENTFUL_APP_MANIFEST}`, JSON.stringify(appManifest, null, 2));
 }
 


### PR DESCRIPTION
There is a small bug in the ```generate-function``` logic where the newest app-manifest entry is altered for the function name. An extraneous './' was included at the start; ```upload``` cannot find the correct build path.

This PR removes the extraneous './'