### PR TITLE
feat: examples come from new repository [EXT-6246]

### DIFF
--- a/packages/contentful--create-contentful-app/src/constants.ts
+++ b/packages/contentful--create-contentful-app/src/constants.ts
@@ -1,6 +1,6 @@
 export const CREATE_APP_DEFINITION_GUIDE_URL =
   'https://ctfl.io/app-tutorial#embed-your-app-in-the-contentful-web-app';
-export const EXAMPLES_REPO_URL = 'https://github.com/contentful/apps/tree/master/examples';
+export const REPO_URL = 'https://github.com/contentful/create-contentful-app-examples/tree/main';
 // These are the examples that are listed as templates instead of examples
 // OR should otherwise not be included in the list of examples displayed in the interactive mode
 export const IGNORED_EXAMPLE_FOLDERS = [
@@ -12,6 +12,25 @@ export const IGNORED_EXAMPLE_FOLDERS = [
   'hosted-app-action-templates',
   'function-templates',
 ] as const;
-export const EXAMPLES_PATH = 'contentful/apps/examples/';
+interface GithubPathFunction {
+  (version?: string): string;
+}
+
+export const examples_path: GithubPathFunction = function (version = CURRENT_VERSION) {
+  return `contentful/create-contentful-app-examples/v${version}/examples/`;
+};
+
+export const templates_path: GithubPathFunction = function (version = CURRENT_VERSION) {
+  return `contentful/create-contentful-app-examples/v${version}/templates/`;
+}
+
 export const CONTENTFUL_APP_MANIFEST = 'contentful-app-manifest.json';
 export const IGNORED_CLONED_FILES = [CONTENTFUL_APP_MANIFEST, `package.json`];
+
+export const VERSION_1 = "1"
+export const VERSION_2 = "2"
+
+export const CURRENT_VERSION = VERSION_1 // what is currently being used
+export const LEGACY_VERSION = VERSION_1 // the last version that was used
+export const NEWEST_VERSION = VERSION_2 // the most recent version (not always current version)
+export const NEXT_VERSION = VERSION_2 // the next version that will be used (if current < newest)

--- a/packages/contentful--create-contentful-app/src/constants.ts
+++ b/packages/contentful--create-contentful-app/src/constants.ts
@@ -29,6 +29,7 @@ export const IGNORED_CLONED_FILES = [CONTENTFUL_APP_MANIFEST, `package.json`];
 
 export const VERSION_1 = "1"
 export const VERSION_2 = "2"
+export const ALL_VERSIONS = [VERSION_1, VERSION_2] // add here if more versions are added
 
 export const CURRENT_VERSION = VERSION_1 // what is currently being used
 export const LEGACY_VERSION = VERSION_1 // the last version that was used

--- a/packages/contentful--create-contentful-app/src/getGithubFolderNames.ts
+++ b/packages/contentful--create-contentful-app/src/getGithubFolderNames.ts
@@ -7,12 +7,13 @@ interface ContentResponse {
   name: string;
 }
 
-export const CONTENTFUL_APPS_EXAMPLE_FOLDER =
-  'https://api.github.com/repos/contentful/apps/contents/examples';
-
-export async function getGithubFolderNames(): Promise<string[]> {
+export async function getGithubFolderNames(version : string, isExample = true): Promise<string[]> {
+  const CONTENTFUL_APPS_EXAMPLE_FOLDER =
+    `https://api.github.com/repos/contentful/create-contentful-app-examples/contents/v${version}/examples`;
+  const CONTENTFUL_APPS_TEMPLATE_FOLDER =
+    `https://api.github.com/repos/contentful/create-contentful-app-examples/contents/v${version}/templates`;
   try {
-    const response = await fetch(CONTENTFUL_APPS_EXAMPLE_FOLDER);
+    const response = isExample ? await fetch(CONTENTFUL_APPS_EXAMPLE_FOLDER) : await fetch(CONTENTFUL_APPS_TEMPLATE_FOLDER);
     if (!response.ok) {
       throw new HTTPResponseError(
         `${chalk.red('Error:')} Failed to fetch Contentful app templates: ${response.status} ${

--- a/packages/contentful--create-contentful-app/src/index.ts
+++ b/packages/contentful--create-contentful-app/src/index.ts
@@ -99,7 +99,6 @@ async function validateAppName(appName: string): Promise<string> {
 }
 
 async function initProject(appName: string, options: CLIOptions) {
-  console.dir(options, { depth: null });
   const normalizedOptions = normalizeOptions(options) as CLIOptions
 
   try {

--- a/packages/contentful--create-contentful-app/src/index.ts
+++ b/packages/contentful--create-contentful-app/src/index.ts
@@ -11,8 +11,8 @@ import { detectManager, exec, normalizeOptions, isContentfulTemplate } from './u
 import { CLIOptions } from './types';
 import { code, error, highlight, success, warn, wrapInBlanks } from './logger';
 import chalk from 'chalk';
-import { CREATE_APP_DEFINITION_GUIDE_URL, EXAMPLES_REPO_URL } from './constants';
-import { getTemplateSource } from './getTemplateSource';
+import { CREATE_APP_DEFINITION_GUIDE_URL, CURRENT_VERSION, REPO_URL, LEGACY_VERSION } from './constants';
+import { getPathSource } from './getTemplateSource';
 import { track } from './analytics';
 import { cloneAppAction } from './includeAppAction';
 import { cloneFunction } from './includeFunction';
@@ -99,7 +99,8 @@ async function validateAppName(appName: string): Promise<string> {
 }
 
 async function initProject(appName: string, options: CLIOptions) {
-  const normalizedOptions = normalizeOptions(options);
+  console.dir(options, { depth: null });
+  const normalizedOptions = normalizeOptions(options) as CLIOptions
 
   try {
     appName = await validateAppName(appName);
@@ -116,7 +117,7 @@ async function initProject(appName: string, options: CLIOptions) {
       !normalizedOptions.function &&
       !normalizedOptions.action;
 
-    const templateSource = await getTemplateSource(options);
+    const templateSource = await getPathSource(normalizedOptions);
 
     track({
       template: templateSource,
@@ -181,7 +182,7 @@ async function initProject(appName: string, options: CLIOptions) {
         '',
         code('  create-contentful-app my-app --source "github:user/repo"'),
         '',
-        `Official Contentful templates and examples are hosted at ${highlight(EXAMPLES_REPO_URL)}.`,
+        `Official Contentful templates and examples are hosted at ${highlight(REPO_URL)}.`,
       ].join('\n')
     )
     .argument('[app-name]', 'app name')
@@ -189,7 +190,7 @@ async function initProject(appName: string, options: CLIOptions) {
     .option('--yarn', 'use Yarn')
     .option('-ts, --typescript', 'use TypeScript template (default)')
     .option('-js, --javascript', 'use JavaScript template')
-    .option('-e, --example <example-name>', `bootstrap an example app from ${EXAMPLES_REPO_URL}`)
+    .option('-e, --example <example-name>', `bootstrap an example app from ${REPO_URL}`)
     .option(
       '-s, --source <url>',
       [
@@ -201,6 +202,9 @@ async function initProject(appName: string, options: CLIOptions) {
     )
     .option('-a, --action', 'include a hosted app action in the ts or js template')
     .option('-f, --function [function-template-name]', 'include the specified function template')
+    .option('-l --legacy', `Use the last version of app templates and examples (version ${chalk.green(LEGACY_VERSION)})`)
+    .option('-n --next', `Use the next version of app templates and examples, if it exists (version ${chalk.green(CURRENT_VERSION)})`)
+    .option('-v --version [version-number]', `Select the app examples version to use. Default is the most current version (version ${chalk.green(CURRENT_VERSION)})`)
     .action(initProject);
   await program.parseAsync();
 })();

--- a/packages/contentful--create-contentful-app/src/types.ts
+++ b/packages/contentful--create-contentful-app/src/types.ts
@@ -7,6 +7,9 @@ export type CLIOptions = Partial<{
   example: string;
   action: boolean;
   function: string | boolean;
+  legacy: boolean;
+  next: boolean;
+  version: string;
 }>;
 
 export const ContentfulExample = {

--- a/packages/contentful--create-contentful-app/src/utils.ts
+++ b/packages/contentful--create-contentful-app/src/utils.ts
@@ -3,7 +3,7 @@ import { existsSync, rmSync } from 'fs';
 import { basename } from 'path';
 import { choice, highlight, warn } from './logger';
 import { CLIOptions, ContentfulExample } from './types';
-import { EXAMPLES_PATH } from './constants';
+import { CURRENT_VERSION, examples_path, LEGACY_VERSION, NEWEST_VERSION, NEXT_VERSION, templates_path } from './constants';
 
 const MUTUALLY_EXCLUSIVE_OPTIONS = ['source', 'example', 'typescript', 'javascript'] as const;
 
@@ -49,6 +49,27 @@ export function normalizeOptions(options: CLIOptions): CLIOptions {
     delete normalizedOptions.yarn;
   }
 
+  if (!normalizedOptions.version) { // version takes precedence over legacy
+    if (normalizedOptions.legacy) {
+      normalizedOptions.version = LEGACY_VERSION;
+    }  else if (normalizedOptions.next) {
+      normalizedOptions.version = NEXT_VERSION
+    } else {
+        normalizedOptions.version = CURRENT_VERSION;
+    }
+  } else {
+    const version = parseInt(normalizedOptions.version);
+    const newestVersion = parseInt(NEWEST_VERSION);
+    if (isNaN(version) || version > newestVersion || version <= 0) {
+    warn(
+      `Provided version ${highlight(normalizedOptions.version)} does not exist, using ${choice(
+        NEWEST_VERSION
+      )} instead.`
+    );
+    normalizedOptions.version = NEWEST_VERSION
+  }
+  }
+
   if (!normalizedOptions.yarn) {
     normalizedOptions.npm = true;
   }
@@ -92,5 +113,6 @@ export function normalizeOptions(options: CLIOptions): CLIOptions {
 }
 
 export function isContentfulTemplate(url: string) {
-  return Object.values(ContentfulExample).some((t) => url.includes(EXAMPLES_PATH + t));
+  return Object.values(ContentfulExample).some((t) => 
+    url.includes(templates_path("1") + t)) || url.includes(templates_path("2")) || url.includes(examples_path("1")) || url.includes(examples_path("2"));  
 }

--- a/packages/contentful--create-contentful-app/src/utils.ts
+++ b/packages/contentful--create-contentful-app/src/utils.ts
@@ -55,9 +55,9 @@ export function normalizeOptions(options: CLIOptions): CLIOptions {
 
   if (isNaN(version) || version > newestVersion || version <= 0) {
     warn(
-      `Provided version ${highlight(normalizedOptions.version)} does not exist, using ${choice(NEWEST_VERSION)} instead.`
+      `Provided version ${highlight(normalizedOptions.version)} does not exist, using ${choice(CURRENT_VERSION)} instead.`
     );
-    normalizedOptions.version = NEWEST_VERSION;
+    normalizedOptions.version = CURRENT_VERSION;
   }
 } else {
   // If no version is provided, set it based on legacy or next flags

--- a/packages/contentful--create-contentful-app/test/getTemplateSource.spec.ts
+++ b/packages/contentful--create-contentful-app/test/getTemplateSource.spec.ts
@@ -1,13 +1,13 @@
 import { expect } from 'chai';
 import inquirer from 'inquirer';
 import sinon from 'sinon';
-import { EXAMPLES_PATH } from '../src/constants';
+import { CURRENT_VERSION, examples_path, templates_path } from '../src/constants';
 import * as getGithubFolderNamesModule from '../src/getGithubFolderNames';
-import { getTemplateSource, makeContentfulExampleSource } from '../src/getTemplateSource';
+import { getPathSource,  generateSource } from '../src/getTemplateSource';
 import { ContentfulExample, InvalidTemplateError } from '../src/types';
 
-describe('getTemplateSource', () => {
-  describe('makeContentfulExampleSource', () => {
+describe('getPathSource', () => {
+  describe('generateSource', () => {
     let getGithubFolderNamesStub;
     let promptStub;
 
@@ -23,15 +23,15 @@ describe('getTemplateSource', () => {
     it('should return template source with valid example template', async () => {
       getGithubFolderNamesStub.resolves(['home-location', 'page-location']);
 
-      const templateSource = await makeContentfulExampleSource({ example: 'home-location' });
-      expect(templateSource).to.equal(`${EXAMPLES_PATH}home-location`);
+      const templateSource = await generateSource({ example: 'home-location' });
+      expect(templateSource).to.equal(`${examples_path(CURRENT_VERSION)}home-location`);
     });
 
     it('should throw an error with invalid example template', async () => {
       getGithubFolderNamesStub.resolves(['home-location', 'page-location']);
 
       try {
-        const templateSource = await makeContentfulExampleSource({ example: 'invalid' });
+        const templateSource = await generateSource({ example: 'invalid' });
         console.log(templateSource);
       } catch (error) {
         expect(error instanceof InvalidTemplateError).to.be.true;
@@ -39,33 +39,34 @@ describe('getTemplateSource', () => {
     });
 
     it('should return template source with valid javascript template option', async () => {
-      const templateSource = await makeContentfulExampleSource({ javascript: true });
-      expect(templateSource).to.equal(`${EXAMPLES_PATH}${ContentfulExample.Javascript}`);
+      const templateSource = await generateSource({ javascript: true });
+      expect(templateSource).to.equal(`${templates_path(CURRENT_VERSION)}${ContentfulExample.Javascript}`);
     });
 
     it('should return template source with valid typescript template option', async () => {
-      const templateSource = await makeContentfulExampleSource({ typescript: true });
-      expect(templateSource).to.equal(`${EXAMPLES_PATH}${ContentfulExample.Typescript}`);
+      const templateSource = await generateSource({ typescript: true });
+      expect(templateSource).to.equal(`${templates_path(CURRENT_VERSION)}${ContentfulExample.Typescript}`);
     });
 
     it('should return typescript template source with function option', async () => {
-      const templateSource = await makeContentfulExampleSource({ function: 'function-appaction' });
-      expect(templateSource).to.equal(`${EXAMPLES_PATH}${ContentfulExample.Typescript}`);
+      const templateSource = await generateSource({ function: 'function-appaction' });
+      expect(templateSource).to.equal(`${templates_path(CURRENT_VERSION)}${ContentfulExample.Typescript}`);
     });
 
     it('should return typescript template source with action option', async () => {
-      const templateSource = await makeContentfulExampleSource({ function: true });
-      expect(templateSource).to.equal(`${EXAMPLES_PATH}${ContentfulExample.Typescript}`);
+      const templateSource = await generateSource({ function: true });
+      expect(templateSource).to.equal(`${templates_path(CURRENT_VERSION)}${ContentfulExample.Typescript}`);
     });
 
     it('should return prompt example selection if no options are provided', async () => {
+      getGithubFolderNamesStub.resolves(['home-location', 'page-location']);
       promptStub.resolves({ starter: 'template', language: 'vite-react' });
-      const templateSource = await makeContentfulExampleSource({});
-      expect(templateSource).to.equal(`${EXAMPLES_PATH}vite-react`);
+      const templateSource = await generateSource({});
+      expect(templateSource).to.equal(`${templates_path(CURRENT_VERSION)}vite-react`);
     });
   });
 
-  describe('getTemplateSource', async () => {
+  describe('getPathSource', async () => {
     let consoleLogSpy;
 
     beforeEach(() => {
@@ -77,15 +78,15 @@ describe('getTemplateSource', () => {
     });
 
     it('should return source without a warning when it is a Contentful template', async () => {
-      const source = `${EXAMPLES_PATH}${ContentfulExample.Typescript}`;
-      const sourceResult = await getTemplateSource({ source });
+      const source = `${templates_path(CURRENT_VERSION)}${ContentfulExample.Typescript}`;
+      const sourceResult = await getPathSource({ source });
       expect(sourceResult).to.equal(source);
       expect(consoleLogSpy.calledOnce).to.be.false;
     });
 
     it('should provide warning if source is not a Contentful template', async () => {
       const source = 'my-source';
-      const sourceResult = await getTemplateSource({ source });
+      const sourceResult = await getPathSource({ source });
       expect(sourceResult).to.equal(source);
       expect(consoleLogSpy.getCall(0).args[0]).to.include('Warning');
     });


### PR DESCRIPTION
### Purpose
We are moving our examples from ```apps``` to ```contentful-create-app-examples```.

### Approach
The current version is still pointed at v1, but can be altered easily via a constant.

1. Added ```-l, --legacy``` flag, which points to the previous version (in this case, still v1)
2. Added ```-n, --next``` flag, which points to the next version
3. Added ```-v, --version``` flag which allows you to point to any existing version. If the version doesn't exist, points to the current version.

I also made a change to the prompt logic. Instead of hardcoding templates in, we get the folders through GitHub (like we do for examples). I also made several semantic changes to avoid confusion caused by overlapping meanings to 'template.'

### Context
[Jira](https://contentful.atlassian.net/browse/EXT-6246)