### PR TITLE
fix: Simplified input and correct navigation in new structure [EXT-6255]

### DIFF
--- a/packages/contentful--app-scripts/src/bin.ts
+++ b/packages/contentful--app-scripts/src/bin.ts
@@ -121,10 +121,9 @@ async function runCommand(command: Command, options?: any) {
   program
     .command('generate-function')
     .description('Generate a new Contentful Function')
-    .option('--name <name>', 'Name of the function')
-    .option('--template <language>', 'Select a template and language for the function')
-    .option('--example <example_name>', 'Select an example function to generate')
-    .option('--language <language>', 'Select a language for the function')
+    .option('-n, --name <name>', 'Name of the function')
+    .option('-s, --source <sourceName>', 'Name of the template')
+    .option('-l, --language <language>', 'Select a language for the function')
     .action(async (options) => {
       await runCommand(generateFunction, options);
     });

--- a/packages/contentful--app-scripts/src/bin.ts
+++ b/packages/contentful--app-scripts/src/bin.ts
@@ -122,7 +122,7 @@ async function runCommand(command: Command, options?: any) {
     .command('generate-function')
     .description('Generate a new Contentful Function')
     .option('-n, --name <name>', 'Name of the function')
-    .option('-s, --source <sourceName>', 'Name of the template')
+    .option('-e, --example <example>', 'Name of the reference example')
     .option('-l, --language <language>', 'Select a language for the function')
     .action(async (options) => {
       await runCommand(generateFunction, options);

--- a/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.test.ts
+++ b/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.test.ts
@@ -1,4 +1,4 @@
-import { GenerateFunctionOptions, GenerateFunctionSettings } from "../types";
+import { GenerateFunctionSettings } from "../types";
 import assert from 'node:assert'
 import { buildGenerateFunctionSettingsFromOptions } from './build-generate-function-settings';
 
@@ -6,31 +6,15 @@ describe('buildGenerateFunctionSettingsFromOptions', () => {
     it('should return GenerateFunctionSettings - using minimum template', async () => {
         const options = {
             name: 'test',
-            template: 'typescript',
-        } as GenerateFunctionOptions
+            source: 'APPEVENT-HANDLER',
+            language: 'typescript'
+        } as GenerateFunctionSettings
         const expected = {
             name: 'test',
-            sourceType: 'template',
-            sourceName: 'typescript',
+            source: 'appevent-handler',
             language: 'typescript',
         } as GenerateFunctionSettings
         
-        const settings = await buildGenerateFunctionSettingsFromOptions(options);
-        assert.deepEqual(expected, settings);
-    });
-
-    it('should return GenerateFunctionSettings - using minimum example', async () => {
-        const options = {
-            name: 'test',
-            example: 'appevent-handler',
-            language: 'typescript'
-        } as GenerateFunctionOptions
-        const expected = {
-            name: 'test',
-            sourceType: 'example',
-            sourceName: 'appevent-handler',
-            language: 'typescript',
-        }
         const settings = await buildGenerateFunctionSettingsFromOptions(options);
         assert.deepEqual(expected, settings);
     });

--- a/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.test.ts
+++ b/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.test.ts
@@ -1,21 +1,21 @@
 import { GenerateFunctionSettings } from "../types";
 import assert from 'node:assert'
-import { buildGenerateFunctionSettingsFromOptions } from './build-generate-function-settings';
+import { buildGenerateFunctionSettingsCLI } from './build-generate-function-settings';
 
-describe('buildGenerateFunctionSettingsFromOptions', () => {
+describe('buildGenerateFunctionSettingsCLI', () => {
     it('should return GenerateFunctionSettings - using minimum template', async () => {
         const options = {
             name: 'test',
-            source: 'APPEVENT-HANDLER',
+            example: 'APPEVENT-HANDLER',
             language: 'typescript'
         } as GenerateFunctionSettings
         const expected = {
             name: 'test',
-            source: 'appevent-handler',
+            example: 'appevent-handler',
             language: 'typescript',
         } as GenerateFunctionSettings
         
-        const settings = await buildGenerateFunctionSettingsFromOptions(options);
+        const settings = await buildGenerateFunctionSettingsCLI(options);
         assert.deepEqual(expected, settings);
     });
 })

--- a/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.ts
+++ b/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.ts
@@ -22,13 +22,13 @@ export async function buildGenerateFunctionSettings() : Promise<GenerateFunction
   const sourceSpecificSettings = await inquirer.prompt<GenerateFunctionSettings>([
       {
           name: 'source',
-          message: 'Select an example:',
+          message: 'Select a template:',
           type: 'list',
           choices: filteredSources,
       },
       {
           name: 'language',
-          message: 'Pick a template',
+          message: 'Select a language',
           type: 'list',
           choices: [
               { name: 'TypeScript', value: 'typescript' },

--- a/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.ts
+++ b/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.ts
@@ -21,8 +21,8 @@ export async function buildGenerateFunctionSettings() : Promise<GenerateFunction
 
   const sourceSpecificSettings = await inquirer.prompt<GenerateFunctionSettings>([
       {
-          name: 'source',
-          message: 'Select a template:',
+          name: 'example',
+          message: 'Select an example:',
           type: 'list',
           choices: filteredSources,
       },
@@ -37,15 +37,15 @@ export async function buildGenerateFunctionSettings() : Promise<GenerateFunction
           default: 'typescript',
       }
   ])
-  baseSettings.source = sourceSpecificSettings.source
+  baseSettings.example = sourceSpecificSettings.example
   baseSettings.language = sourceSpecificSettings.language
   return baseSettings
 }
 
 function validateArguments(options: GenerateFunctionSettings) {
-  const requiredParams = ['name', 'source', 'language'];
+  const requiredParams = ['name', 'example', 'language'];
   if (!requiredParams.every((key) => key in options)) {
-      throw new Error('You must specify a function name, a source, and a language');
+      throw new Error('You must specify a function name, an example, and a language');
   } 
    if (BANNED_FUNCTION_NAMES.includes(options.name)) {
     throw new Error(`Invalid function name: ${options.name}`);
@@ -72,8 +72,8 @@ export async function buildGenerateFunctionSettingsFromOptions(options: Generate
         
       // Check if the source exists
       const filteredSources = await getGithubFolderNames();
-      if (!filteredSources.includes(options.source)) {
-        throw new Error(`Invalid source name: ${options.source}. Please choose from: ${filteredSources.join(', ')}`);
+      if (!filteredSources.includes(options.example)) {
+        throw new Error(`Invalid example name: ${options.example}. Please choose from: ${filteredSources.join(', ')}`);
       }
       
       // Check if the language is valid
@@ -84,7 +84,7 @@ export async function buildGenerateFunctionSettingsFromOptions(options: Generate
         settings.language = options.language;
       }
 
-      settings.source = options.source;
+      settings.example = options.example;
       settings.name = options.name;
       return settings;
     } catch (err: any) {

--- a/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.ts
+++ b/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.ts
@@ -7,7 +7,7 @@ import ora from 'ora';
 import chalk from 'chalk';
 import { warn } from './logger';
 
-export async function buildGenerateFunctionSettings() : Promise<GenerateFunctionSettings> {
+export async function buildGenerateFunctionSettingsInteractive() : Promise<GenerateFunctionSettings> {
   const baseSettings = await inquirer.prompt<GenerateFunctionSettings>([
     {
       name: 'name',
@@ -64,7 +64,7 @@ function validateArguments(options: GenerateFunctionSettings) {
   }
 }
 
-export async function buildGenerateFunctionSettingsFromOptions(options: GenerateFunctionSettings) : Promise<GenerateFunctionSettings> {
+export async function buildGenerateFunctionSettingsCLI(options: GenerateFunctionSettings) : Promise<GenerateFunctionSettings> {
   const validateSpinner = ora('Validating your input\n').start();
   const settings: GenerateFunctionSettings = {} as GenerateFunctionSettings;
     try {

--- a/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.ts
+++ b/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.ts
@@ -1,7 +1,7 @@
 import inquirer from 'inquirer';
 import path from 'path';
 import { getGithubFolderNames } from './get-github-folder-names';
-import { ACCEPTED_EXAMPLE_FOLDERS, ACCEPTED_LANGUAGES, BANNED_FUNCTION_NAMES } from './constants';
+import { ACCEPTED_LANGUAGES, BANNED_FUNCTION_NAMES } from './constants';
 import { GenerateFunctionSettings, Language } from '../types';
 import ora from 'ora';
 import chalk from 'chalk';
@@ -17,30 +17,29 @@ export async function buildGenerateFunctionSettings() : Promise<GenerateFunction
   if (BANNED_FUNCTION_NAMES.includes(baseSettings.name)) {
     throw new Error(`Invalid function name: ${baseSettings.name}`);
   }
-  let sourceSpecificSettings : GenerateFunctionSettings;
   const filteredSources = await getGithubFolderNames();
 
-    sourceSpecificSettings = await inquirer.prompt<GenerateFunctionSettings>([
-        {
-            name: 'source',
-            message: 'Select an example:',
-            type: 'list',
-            choices: filteredSources,
-        },
-        {
-            name: 'language',
-            message: 'Pick a template',
-            type: 'list',
-            choices: [
-                { name: 'TypeScript', value: 'typescript' },
-                { name: 'JavaScript', value: 'javascript' },
-            ],
-            default: 'typescript',
-        }
-    ])
-    baseSettings.source = sourceSpecificSettings.source
-    baseSettings.language = sourceSpecificSettings.language
-    return baseSettings
+  const sourceSpecificSettings = await inquirer.prompt<GenerateFunctionSettings>([
+      {
+          name: 'source',
+          message: 'Select an example:',
+          type: 'list',
+          choices: filteredSources,
+      },
+      {
+          name: 'language',
+          message: 'Pick a template',
+          type: 'list',
+          choices: [
+              { name: 'TypeScript', value: 'typescript' },
+              { name: 'JavaScript', value: 'javascript' },
+          ],
+          default: 'typescript',
+      }
+  ])
+  baseSettings.source = sourceSpecificSettings.source
+  baseSettings.language = sourceSpecificSettings.language
+  return baseSettings
 }
 
 function validateArguments(options: GenerateFunctionSettings) {

--- a/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.ts
+++ b/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.ts
@@ -2,7 +2,7 @@ import inquirer from 'inquirer';
 import path from 'path';
 import { getGithubFolderNames } from './get-github-folder-names';
 import { ACCEPTED_EXAMPLE_FOLDERS, ACCEPTED_LANGUAGES, BANNED_FUNCTION_NAMES } from './constants';
-import { GenerateFunctionSettings, AcceptedFunctionExamples, SourceName, GenerateFunctionOptions, Language } from '../types';
+import { GenerateFunctionSettings, Language } from '../types';
 import ora from 'ora';
 import chalk from 'chalk';
 import { warn } from './logger';
@@ -13,48 +13,19 @@ export async function buildGenerateFunctionSettings() : Promise<GenerateFunction
       name: 'name',
       message: `Function name (${path.basename(process.cwd())}):`,
     },
-    {
-      name: 'sourceType',
-      message: 'Do you want to start with a blank template or use one of our examples?',
-      type: 'list',
-      choices: [
-        { name: 'Template', value: 'template' },
-        { name: 'Example', value: 'example' },
-      ],
-      default: 'template',
-    }
   ]);
   if (BANNED_FUNCTION_NAMES.includes(baseSettings.name)) {
     throw new Error(`Invalid function name: ${baseSettings.name}`);
   }
   let sourceSpecificSettings : GenerateFunctionSettings;
-  if (baseSettings.sourceType === 'template') {
-    sourceSpecificSettings = await inquirer.prompt<GenerateFunctionSettings>([
-        {
-            name: 'language',
-            message: 'Pick a template',
-            type: 'list',
-            choices: [
-                { name: 'TypeScript', value: 'typescript' },
-                { name: 'JavaScript', value: 'javascript' },
-            ],
-            default: 'typescript',
-        }
-    ])
-    sourceSpecificSettings.sourceName = sourceSpecificSettings.language.toLowerCase() as SourceName
-  } else {
-    const availableExamples = await getGithubFolderNames();
-    const filteredExamples = availableExamples.filter(
-      (template) =>
-        ACCEPTED_EXAMPLE_FOLDERS.includes(template as (typeof ACCEPTED_EXAMPLE_FOLDERS)[number])
-    );
+  const filteredSources = await getGithubFolderNames();
 
     sourceSpecificSettings = await inquirer.prompt<GenerateFunctionSettings>([
         {
-            name: 'sourceName',
+            name: 'source',
             message: 'Select an example:',
             type: 'list',
-            choices: filteredExamples,
+            choices: filteredSources,
         },
         {
             name: 'language',
@@ -67,76 +38,55 @@ export async function buildGenerateFunctionSettings() : Promise<GenerateFunction
             default: 'typescript',
         }
     ])
-  }
-    baseSettings.sourceName = sourceSpecificSettings.sourceName
+    baseSettings.source = sourceSpecificSettings.source
     baseSettings.language = sourceSpecificSettings.language
     return baseSettings
 }
 
-function validateArguments(options: GenerateFunctionOptions) {
-  const templateRequired = ['name', 'template'];
-  const exampleRequired = ['name', 'example', 'language'];
-  if (BANNED_FUNCTION_NAMES.includes(options.name)) {
+function validateArguments(options: GenerateFunctionSettings) {
+  const requiredParams = ['name', 'source', 'language'];
+  if (!requiredParams.every((key) => key in options)) {
+      throw new Error('You must specify a function name, a source, and a language');
+  } 
+   if (BANNED_FUNCTION_NAMES.includes(options.name)) {
     throw new Error(`Invalid function name: ${options.name}`);
   }
-  if ('template' in options) {
-    if (!templateRequired.every((key) => key in options)) {
-      throw new Error('You must specify a function name and a template');
+  // Convert options to lowercase and trim whitespace
+  for (const key in options) {
+    const optionKey = key as keyof GenerateFunctionSettings;
+    const value = options[optionKey].toLowerCase().trim();
+    
+    if (optionKey === 'language') {
+      // Assert that the value is of type Language
+      options[optionKey] = value as Language;
+    } else {
+      options[optionKey] = value;
     }
-  } else if ('example' in options) {
-      if (!exampleRequired.every((key) => key in options)) {
-        throw new Error('You must specify a function name, an example, and a language');
-      } 
-  } else {
-    throw new Error('You must specify either --template or --example');
   }
 }
 
-export async function buildGenerateFunctionSettingsFromOptions(options: GenerateFunctionOptions) : Promise<GenerateFunctionSettings> {
+export async function buildGenerateFunctionSettingsFromOptions(options: GenerateFunctionSettings) : Promise<GenerateFunctionSettings> {
   const validateSpinner = ora('Validating your input\n').start();
   const settings: GenerateFunctionSettings = {} as GenerateFunctionSettings;
     try {
       validateArguments(options);
-      for (const key in options) { // convert all options to lowercase and trim
-        const optionKey = key as keyof GenerateFunctionOptions;
-        options[optionKey] = options[optionKey].toLowerCase().trim();
+        
+      // Check if the source exists
+      const filteredSources = await getGithubFolderNames();
+      if (!filteredSources.includes(options.source)) {
+        throw new Error(`Invalid source name: ${options.source}. Please choose from: ${filteredSources.join(', ')}`);
+      }
+      
+      // Check if the language is valid
+      if (!ACCEPTED_LANGUAGES.includes(options.language)) {
+        warn(`Invalid language: ${options.language}. Defaulting to TypeScript.`);
+        settings.language = 'typescript';
+      } else {
+        settings.language = options.language;
       }
 
-      if ('example' in options) {
-        if ('template' in options) {
-          throw new Error('Cannot specify both --template and --example');
-        }
-        
-        if (!ACCEPTED_EXAMPLE_FOLDERS.includes(options.example as AcceptedFunctionExamples)) {
-          throw new Error(`Invalid example name: ${options.example}`);
-        }
-        
-        if (!ACCEPTED_LANGUAGES.includes(options.language)) {
-          warn(`Invalid language: ${options.language}. Defaulting to TypeScript.`);
-          settings.language = 'typescript';
-        } else {
-          settings.language = options.language;
-        }
-        settings.sourceType = 'example';
-        settings.sourceName = options.example;
-        settings.name = options.name;
-
-      } else if ('template' in options) {
-        if ('language' in options && options.language && options.language != options.template) {
-          console.warn(`Ignoring language option: ${options.language}. Defaulting to ${options.template}.`);
-        }
-        if (!ACCEPTED_LANGUAGES.includes(options.template as Language)) {
-          console.warn(`Invalid language: ${options.template}. Defaulting to TypeScript.`);
-          settings.language = 'typescript';
-          settings.sourceName = 'typescript';
-        } else {
-          settings.language = options.template as Language;
-          settings.sourceName = options.template;
-        }
-        settings.sourceType = 'template';
-        settings.name = options.name;
-      }
-
+      settings.source = options.source;
+      settings.name = options.name;
       return settings;
     } catch (err: any) {
       console.log(`

--- a/packages/contentful--app-scripts/src/generate-function/clone.test.ts
+++ b/packages/contentful--app-scripts/src/generate-function/clone.test.ts
@@ -20,21 +20,15 @@ import { GenerateFunctionSettings, Language } from '../types';
 
 let settings = {
   name: 'myFunction',
-  source: 'typescript',
+  example: 'typescript',
   language: 'typescript'
 } as GenerateFunctionSettings;
 
 describe('Helper functions tests', () => {
 
   describe('getCloneURL', () => {
-    it('should return default clone URL for non-example sourceType', () => {
-      const expected = `${REPO_URL}/${settings.source}/${settings.language}`;
-      const url = getCloneURL(settings);
-      assert.strictEqual(url, expected);
-    });
-
-    it('should return example clone URL when sourceType is example', () => {
-      const expected = `${REPO_URL}/${settings.source}/${settings.language}`;
+    it('should return example clone URL when exampleType is example', () => {
+      const expected = `${REPO_URL}/${settings.example}/${settings.language}`;
       const url = getCloneURL(settings);
       assert.strictEqual(url, expected);
     });

--- a/packages/contentful--app-scripts/src/generate-function/clone.test.ts
+++ b/packages/contentful--app-scripts/src/generate-function/clone.test.ts
@@ -30,14 +30,14 @@ describe('Helper functions tests', () => {
   describe('getCloneURL', () => {
     it('should return default clone URL for non-example sourceType', () => {
       const settings = { ...dummySettings, sourceType: 'template' } as GenerateFunctionSettings;
-      const expected = `${REPO_URL}/${settings.sourceName}`;
+      const expected = `${REPO_URL}/${settings.source}/${settings.language}`;
       const url = getCloneURL(settings);
       assert.strictEqual(url, expected);
     });
 
     it('should return example clone URL when sourceType is example', () => {
       const settings = { ...dummySettings, sourceType: 'example' } as GenerateFunctionSettings;
-      const expected = `${REPO_URL}/${settings.sourceName}/${settings.language}`;
+      const expected = `${REPO_URL}/${settings.source}/${settings.language}`;
       const url = getCloneURL(settings);
       assert.strictEqual(url, expected);
     });

--- a/packages/contentful--app-scripts/src/generate-function/clone.test.ts
+++ b/packages/contentful--app-scripts/src/generate-function/clone.test.ts
@@ -18,10 +18,9 @@ import {
 import { REPO_URL, CONTENTFUL_APP_MANIFEST, APP_MANIFEST } from './constants';
 import { GenerateFunctionSettings, Language } from '../types';
 
-const dummySettings = {
+let settings = {
   name: 'myFunction',
-  sourceName: 'typescript',
-  sourceType: 'template',
+  source: 'typescript',
   language: 'typescript'
 } as GenerateFunctionSettings;
 
@@ -29,14 +28,12 @@ describe('Helper functions tests', () => {
 
   describe('getCloneURL', () => {
     it('should return default clone URL for non-example sourceType', () => {
-      const settings = { ...dummySettings, sourceType: 'template' } as GenerateFunctionSettings;
       const expected = `${REPO_URL}/${settings.source}/${settings.language}`;
       const url = getCloneURL(settings);
       assert.strictEqual(url, expected);
     });
 
     it('should return example clone URL when sourceType is example', () => {
-      const settings = { ...dummySettings, sourceType: 'example' } as GenerateFunctionSettings;
       const expected = `${REPO_URL}/${settings.source}/${settings.language}`;
       const url = getCloneURL(settings);
       assert.strictEqual(url, expected);
@@ -59,12 +56,12 @@ describe('Helper functions tests', () => {
 
     it('should update the manifest with new function id, path and entryFile', async () => {
       const renameFile = 'myFunction.ts';
-      await touchupAppManifest(tempDir, dummySettings, renameFile);
+      await touchupAppManifest(tempDir, settings, renameFile);
       const updatedManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
       const entry = updatedManifest.functions[updatedManifest.functions.length - 1];
 
       // The id should be the settings.name
-      assert.strictEqual(entry.id, dummySettings.name);
+      assert.strictEqual(entry.id, settings.name);
       // The path is updated to always have a .js extension
       assert.strictEqual(entry.path, `functions/${renameFile.replace('.ts', '.js')}`);
       // entryFile remains unchanged (uses the original renameFile)
@@ -111,7 +108,6 @@ describe('Helper functions tests', () => {
       const originalFilePath = path.join(tmpDir, originalName);
       fs.writeFileSync(originalFilePath, 'console.log("hello")', 'utf-8');
 
-      const settings = { ...dummySettings, language: 'typescript' } as GenerateFunctionSettings;
       const newName = renameClonedFiles(tmpDir, settings);
       const expectedName = `${settings.name}.ts`;
       assert.strictEqual(newName, expectedName);
@@ -121,7 +117,7 @@ describe('Helper functions tests', () => {
     });
 
     it('should throw an error if no function file is found', () => {
-      const settings = { ...dummySettings, language: 'javascript' } as GenerateFunctionSettings;
+      settings = { ...settings, language: 'javascript' } as GenerateFunctionSettings;
       assert.throws(() => renameClonedFiles(tmpDir, settings), /No function file found/);
     });
   });

--- a/packages/contentful--app-scripts/src/generate-function/clone.ts
+++ b/packages/contentful--app-scripts/src/generate-function/clone.ts
@@ -41,10 +41,7 @@ export async function cloneFunction(
 }
 
 export function getCloneURL(settings: GenerateFunctionSettings) {
-  let cloneURL = `${REPO_URL}/${settings.sourceName}`; // this is the default for template
-  if (settings.sourceType === 'example') {
-    cloneURL = `${REPO_URL}/${settings.sourceName}/${settings.language}`;
-  }
+  let cloneURL = `${REPO_URL}/${settings.source}/${settings.language}`; // this is the default for template
   return cloneURL;
 }
 

--- a/packages/contentful--app-scripts/src/generate-function/clone.ts
+++ b/packages/contentful--app-scripts/src/generate-function/clone.ts
@@ -41,8 +41,7 @@ export async function cloneFunction(
 }
 
 export function getCloneURL(settings: GenerateFunctionSettings) {
-  let cloneURL = `${REPO_URL}/${settings.source}/${settings.language}`; // this is the default for template
-  return cloneURL;
+  return `${REPO_URL}/${settings.source}/${settings.language}`; // this is the default for template
 }
 
 export async function touchupAppManifest(localPath: string, settings: GenerateFunctionSettings, renameFunctionFile: string) {

--- a/packages/contentful--app-scripts/src/generate-function/clone.ts
+++ b/packages/contentful--app-scripts/src/generate-function/clone.ts
@@ -41,7 +41,7 @@ export async function cloneFunction(
 }
 
 export function getCloneURL(settings: GenerateFunctionSettings) {
-  return `${REPO_URL}/${settings.source}/${settings.language}`; // this is the default for template
+  return `${REPO_URL}/${settings.example}/${settings.language}`; // this is the default for template
 }
 
 export async function touchupAppManifest(localPath: string, settings: GenerateFunctionSettings, renameFunctionFile: string) {

--- a/packages/contentful--app-scripts/src/generate-function/index.ts
+++ b/packages/contentful--app-scripts/src/generate-function/index.ts
@@ -1,4 +1,4 @@
-import { GenerateFunctionOptions } from "../types";
+import { GenerateFunctionSettings } from "../types";
 import { buildGenerateFunctionSettings, buildGenerateFunctionSettingsFromOptions } from "./build-generate-function-settings";
 import { create } from "./create-function";
 
@@ -8,7 +8,7 @@ const interactive = async () => {
   return create(generateFunctionSettings);
 };
 
-const nonInteractive = async (options: GenerateFunctionOptions) => {
+const nonInteractive = async (options: GenerateFunctionSettings) => {
     const generateFunctionSettings = await buildGenerateFunctionSettingsFromOptions(options);
     return create(generateFunctionSettings);
 };

--- a/packages/contentful--app-scripts/src/generate-function/index.ts
+++ b/packages/contentful--app-scripts/src/generate-function/index.ts
@@ -1,15 +1,15 @@
 import { GenerateFunctionSettings } from "../types";
-import { buildGenerateFunctionSettings, buildGenerateFunctionSettingsFromOptions } from "./build-generate-function-settings";
+import { buildGenerateFunctionSettingsInteractive, buildGenerateFunctionSettingsCLI } from "./build-generate-function-settings";
 import { create } from "./create-function";
 
 const interactive = async () => {
-  const generateFunctionSettings = await buildGenerateFunctionSettings();
+  const generateFunctionSettings = await buildGenerateFunctionSettingsInteractive();
 
   return create(generateFunctionSettings);
 };
 
 const nonInteractive = async (options: GenerateFunctionSettings) => {
-    const generateFunctionSettings = await buildGenerateFunctionSettingsFromOptions(options);
+    const generateFunctionSettings = await buildGenerateFunctionSettingsCLI(options);
     return create(generateFunctionSettings);
 };
 

--- a/packages/contentful--app-scripts/src/types.ts
+++ b/packages/contentful--app-scripts/src/types.ts
@@ -82,23 +82,9 @@ export interface BuildFunctionsOptions {
   watch?: boolean;
 }
 
-export type SourceType = 'template' | 'example';
 export type Language = 'javascript' | 'typescript';
-export type AcceptedFunctionExamples = 'appevent-handler'; // Union type of each accepted example folder name in apps/function-examples repo
-export type SourceName = Language | AcceptedFunctionExamples;
-
 export interface GenerateFunctionSettings {
   name: string;
-  sourceType: SourceType;
-  sourceName: SourceName;
+  source: string;
   language: Language;
 }
-
-export type GenerateFunctionOptions = {
-  name: string;
-} & ({
-  example: AcceptedFunctionExamples;
-  language: Language
-} | {
-  template: Language;
-})

--- a/packages/contentful--app-scripts/src/types.ts
+++ b/packages/contentful--app-scripts/src/types.ts
@@ -85,6 +85,6 @@ export interface BuildFunctionsOptions {
 export type Language = 'javascript' | 'typescript';
 export interface GenerateFunctionSettings {
   name: string;
-  source: string;
+  example: string;
   language: Language;
 }


### PR DESCRIPTION

### Purpose
We are changing how generate-function pulls from the apps repo.

# Ex Directory Structure
function-example/
├── example1/
│   ├── typescript/
│   ├── javascript/
├── example2/
│   ├── typescript/
│   ├── javascript/
├── example3/
│   ├── typescript/
│   ├── javascript/

## AC
Everything is treated the same now, no notion of a ‘example’ vs ‘template’. 
Must specify language, source, and name for each new function.