### PR TITLE
fix: no duplicate app manifests and better function name validation [EXT-6262]

### DIFF
--- a/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.test.ts
+++ b/packages/contentful--app-scripts/src/generate-function/build-generate-function-settings.test.ts
@@ -1,6 +1,6 @@
 import { GenerateFunctionSettings } from "../types";
 import assert from 'node:assert'
-import { buildGenerateFunctionSettingsCLI } from './build-generate-function-settings';
+import { buildGenerateFunctionSettingsCLI, validateArguments } from './build-generate-function-settings';
 
 describe('buildGenerateFunctionSettingsCLI', () => {
     it('should return GenerateFunctionSettings - using minimum template', async () => {
@@ -17,5 +17,96 @@ describe('buildGenerateFunctionSettingsCLI', () => {
         
         const settings = await buildGenerateFunctionSettingsCLI(options);
         assert.deepEqual(expected, settings);
+    });
+    it('should fail if name is not alphanumeric', async () => {
+        const options = {
+            name: 'test!',
+            example: 'APPEVENT-HANDLER',
+            language: 'javascript'
+        } as GenerateFunctionSettings
+        try {
+            await buildGenerateFunctionSettingsCLI(options);
+        }
+        catch (e) {
+            assert.equal(e.message, '\x1B[31mInvalid function name: test!. Note that function names must be alphanumeric.\x1B[39m');
+        }
+    });
+    it('should fail if name is in banned names', async () => {
+        const options = {
+            name: 'example',
+            example: 'APPEVENT-HANDLER',
+            language: 'javascript'
+        } as GenerateFunctionSettings
+        try {
+            await buildGenerateFunctionSettingsCLI(options);
+        }
+        catch (e) {
+            assert.equal(e.message, '\x1B[31mInvalid function name: example is not allowed.\x1B[39m');
+        }
+    });
+    it('should fail if name is empty', async () => {
+        const options = {
+            example: 'APPEVENT-HANDLER',
+            name: '',
+            language: 'javascript'
+        } as GenerateFunctionSettings
+        try {
+            await buildGenerateFunctionSettingsCLI(options);
+        }
+        catch (e) {
+            assert.equal(e.message, '\x1B[31mInvalid function name:  is not allowed.\x1B[39m');
+        }
+    });
+    it('should fail if name is not provided', async () => {
+        const options = {
+            example: 'APPEVENT-HANDLER',
+            language: 'javascript'
+        } as GenerateFunctionSettings
+        try {
+            await buildGenerateFunctionSettingsCLI(options);
+        }
+        catch (e) {
+            assert.equal(e.message, '\x1B[31mYou must specify a function name, an example, and a language\x1B[39m');
+        }
+    });
+
+    it('should fail if example is not provided', async () => {
+        const options = {
+            name: 'test',
+            language: 'javascript'
+        } as GenerateFunctionSettings
+        try {
+            await buildGenerateFunctionSettingsCLI(options);
+        }
+        catch (e) {
+            assert.equal(e.message, '\x1B[31mYou must specify a function name, an example, and a language\x1B[39m');
+        }
+    });
+    it('should fail if language is not provided', async () => {
+        const options = {
+            name: 'test',
+            example: 'APPEVENT-HANDLER',
+        } as GenerateFunctionSettings
+        try {
+            await buildGenerateFunctionSettingsCLI(options);
+        }
+        catch (e) {
+            assert.equal(e.message, '\x1B[31mYou must specify a function name, an example, and a language\x1B[39m');
+        }
+    });
+
+    it('should continue with typescript if language is not in the list', async () => {
+        const options = {
+            name: 'test',
+            example: 'APPEVENT-HANDLER',
+            language: 'python'
+        } 
+        const expected = {
+            name: 'test',
+            example: 'appevent-handler',
+            language: 'typescript',
+        } as GenerateFunctionSettings
+        validateArguments(options as GenerateFunctionSettings);
+        assert.deepEqual(expected, options);
     });
 })

--- a/packages/contentful--app-scripts/src/generate-function/clone.ts
+++ b/packages/contentful--app-scripts/src/generate-function/clone.ts
@@ -36,12 +36,12 @@ export async function cloneFunction(
     await touchupAppManifest(localPath, settings, renameFunctionFile);
   } catch (e) {
     error(`Failed to clone function ${highlight(chalk.cyan(settings.name))}`, e);
-    process.exit(1);
+    throw Error(chalk.red('Failed to clone function ') + highlight(chalk.cyan(settings.name)));
   }
 }
 
 export function getCloneURL(settings: GenerateFunctionSettings) {
-  return `${REPO_URL}/${settings.example}/${settings.language}`; // this is the default for template
+  return `${REPO_URL}/${settings.example}/${settings.language}`;
 }
 
 export async function touchupAppManifest(localPath: string, settings: GenerateFunctionSettings, renameFunctionFile: string) {

--- a/packages/contentful--app-scripts/src/generate-function/constants.ts
+++ b/packages/contentful--app-scripts/src/generate-function/constants.ts
@@ -1,7 +1,7 @@
 export const EXAMPLES_PATH = 'contentful/apps/function-examples/';
 export const APP_MANIFEST = 'app-manifest.json';
 export const CONTENTFUL_APP_MANIFEST = 'contentful-app-manifest.json';
-export const IGNORED_CLONED_FILES = [APP_MANIFEST, `package.json`];
+export const IGNORED_CLONED_FILES = [APP_MANIFEST, CONTENTFUL_APP_MANIFEST, `package.json`];
 export const REPO_URL = 'https://github.com/contentful/apps/function-examples';
 
 export const ACCEPTED_EXAMPLE_FOLDERS = [
@@ -11,7 +11,7 @@ export const ACCEPTED_EXAMPLE_FOLDERS = [
 export const ACCEPTED_LANGUAGES = ['javascript', 'typescript'];
 
 export const CONTENTFUL_FUNCTIONS_EXAMPLE_REPO_PATH =
-  'https://api.github.com/repos/contentful/apps/contents/function-examples';
+  'https://api.github.com/repos/contentful/apps/contents/function-examples'
 
 export const BANNED_FUNCTION_NAMES = ['example', ''];
   

--- a/packages/contentful--app-scripts/src/generate-function/create-function.ts
+++ b/packages/contentful--app-scripts/src/generate-function/create-function.ts
@@ -5,6 +5,5 @@ import { GenerateFunctionSettings } from "../types";
 export async function create(settings: GenerateFunctionSettings) {
   const localPath = resolve(process.cwd());
   await cloneFunction(localPath, settings);
-
   console.log(`Function "${settings.name}" created successfully`);
 }

--- a/packages/contentful--app-scripts/src/generate-function/index.ts
+++ b/packages/contentful--app-scripts/src/generate-function/index.ts
@@ -1,16 +1,32 @@
 import { GenerateFunctionSettings } from "../types";
 import { buildGenerateFunctionSettingsInteractive, buildGenerateFunctionSettingsCLI } from "./build-generate-function-settings";
 import { create } from "./create-function";
+import { ValidationError } from "./types";
 
 const interactive = async () => {
-  const generateFunctionSettings = await buildGenerateFunctionSettingsInteractive();
-
-  return create(generateFunctionSettings);
+  try {
+    const generateFunctionSettings = await buildGenerateFunctionSettingsInteractive();
+    return create(generateFunctionSettings);
+  } catch (e) {
+    if (e instanceof ValidationError) {
+      console.error(e.message)
+    } else {
+      console.error(e)
+    }
+  }
 };
 
 const nonInteractive = async (options: GenerateFunctionSettings) => {
+  try {
     const generateFunctionSettings = await buildGenerateFunctionSettingsCLI(options);
     return create(generateFunctionSettings);
+  } catch (e) {
+    if (e instanceof ValidationError) {
+      console.error(e.message)
+    } else {
+      console.error(e)
+    }
+  }
 };
 
 export const generateFunction = {

--- a/packages/contentful--app-scripts/src/generate-function/types.ts
+++ b/packages/contentful--app-scripts/src/generate-function/types.ts
@@ -1,2 +1,9 @@
 export class HTTPResponseError extends Error {}
 export class InvalidTemplateError extends Error {}
+
+export class ValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "ValidationError";
+    }
+}


### PR DESCRIPTION
### Purpose
Fix a small bug that adds a duplicate app-manifest to the ```functions``` folder when using ```generate-function```. Also, do early function name validation that will ensure the function can be uploaded.