### PR TITLE
fix: language-flags-with-function-templates [EXT-6291]

### DIFF
--- a/packages/contentful--create-contentful-app/src/index.ts
+++ b/packages/contentful--create-contentful-app/src/index.ts
@@ -146,7 +146,7 @@ async function initProject(appName: string, options: CLIOptions) {
         .replace(/-([a-z])/g, (match, letter) => letter.toUpperCase());
       await generateFunction.nonInteractive({
         example: normalizedOptions.function,
-        language: 'typescript',
+        language: normalizedOptions.typescript ? 'typescript' : 'javascript',
         name: functionName,
       });
     }

--- a/packages/contentful--create-contentful-app/src/index.ts
+++ b/packages/contentful--create-contentful-app/src/index.ts
@@ -146,7 +146,7 @@ async function initProject(appName: string, options: CLIOptions) {
         .replace(/-([a-z])/g, (match, letter) => letter.toUpperCase());
       await generateFunction.nonInteractive({
         example: normalizedOptions.function,
-        language: normalizedOptions.typescript ? 'typescript' : 'javascript',
+        language: normalizedOptions.javascript ? 'javascript' : 'typescript',
         name: functionName,
       });
     }


### PR DESCRIPTION
# Purpose
If someone uses `--javascript` or `--typescript`, they get a _template in that language._ Currently, if they also specify `--function <function-name>`, the function is _always_ typescript. This fixes that - if a user uses the template flag with `--function`, the function is in the language of the template flag.