### PR TITLE
fix: filtering examples [EXT-6293]

### DIFF
--- a/packages/contentful--create-contentful-app/src/constants.ts
+++ b/packages/contentful--create-contentful-app/src/constants.ts
@@ -10,7 +10,6 @@ export const IGNORED_EXAMPLE_FOLDERS = [
   'vite-react',
   'nextjs',
   'hosted-app-action-templates',
-  'function-templates',
 ] as const;
 export const EXAMPLES_PATH = 'contentful/apps/examples/';
 export const CONTENTFUL_APP_MANIFEST = 'contentful-app-manifest.json';

--- a/packages/contentful--create-contentful-app/src/getTemplateSource.ts
+++ b/packages/contentful--create-contentful-app/src/getTemplateSource.ts
@@ -50,7 +50,6 @@ async function promptExampleSelection(): Promise<string> {
         (template) =>
           !IGNORED_EXAMPLE_FOLDERS.includes(template as (typeof IGNORED_EXAMPLE_FOLDERS)[number])
       )
-      .filter((template) => !template.includes('function'));
     console.log(availableTemplates.length, filteredTemplates.length);
 
     // ask user to select a template from the available examples


### PR DESCRIPTION
### Purpose
Currently, interactive mode automatically filters any examples with 'function' in the name. This fixes that and prevents unnecessary filtering.
<img width="820" alt="image" src="https://github.com/user-attachments/assets/a66a3843-e345-4b80-8913-54e6ee091e10" />
