### PR TITLE
fix: rebump all packages [EXT-6447]

### DIFF
--- a/packages/contentful--app-scripts/src/utils.ts
+++ b/packages/contentful--app-scripts/src/utils.ts
@@ -163,7 +163,7 @@ export function getFunctionsFromManifest(): Omit<ContentfulFunction, 'entryFile'
         process.exit(1);
       }
 
-      // EntryFile is not used but we do want to strip it 
+      // EntryFile is not used but we do want to strip it
       // eslint-disable-next-line no-unused-vars
       const { entryFile: _, ...itemWithoutEntryFile } = item;
 

--- a/packages/contentful--create-contentful-app/src/index.ts
+++ b/packages/contentful--create-contentful-app/src/index.ts
@@ -154,7 +154,7 @@ async function initProject(appName: string, options: CLIOptions) {
 
     if (!isInteractive && isContentfulTemplate(templateSource) && normalizedOptions.function) {
       // If function flag is specified, but no function name is provided, we default to external-references
-      // for legacy support 
+      // for legacy support
       if (normalizedOptions.function === true) {
         normalizedOptions.function = 'external-references';
       }

--- a/packages/contentful--react-apps-toolkit/src/SDKProvider.tsx
+++ b/packages/contentful--react-apps-toolkit/src/SDKProvider.tsx
@@ -10,7 +10,7 @@ interface SDKProviderProps {
 const DELAY_TIMEOUT = 4 * 1000;
 
 /**
- * The Component providing the AppSdk, the useSDK hook can only be used within this Provider 
+ * The Component providing the AppSdk, the useSDK hook can only be used within this Provider
  * @param props.loading an optional loading element that gets rendered while initializing the app
  */
 export const SDKProvider: FC<PropsWithChildren<SDKProviderProps>> = (props) => {

--- a/packages/create-contentful-app/index.js
+++ b/packages/create-contentful-app/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// This is a convenience wrapper.
+// This is a convenience wrapper!
 // It allows you to run `npx create-contentful-app` directly,
 // instead of `npx @contentful/create-contentful-app`.
 


### PR DESCRIPTION
Follow up on [this ticket](https://github.com/contentful/create-contentful-app/pull/2533).
The other releases contain the dependencies of the entire create-contentful-app. This means that the stale version from the linked ticket is not updated in the other releases. So, we need to bump the releases.