### PR TITLE
feat(pnpm): support pnpm as package manager

### DIFF
--- a/packages/contentful--create-contentful-app/README.md
+++ b/packages/contentful--create-contentful-app/README.md
@@ -30,6 +30,9 @@ npx create-contentful-app <app-name>
 # npm
 npm init contentful-app <app-name>
 
+# pnpm
+pnpm init contentful-app <app-name>
+
 # Yarn
 yarn create contentful-app <app-name>
 ```
@@ -38,11 +41,9 @@ yarn create contentful-app <app-name>
 
 ### Package Manager
 
-`--npm` or `--yarn`
+`--npm` or `--pnpm` or `--yarn`
 
-Use npm or Yarn to manage dependencies. If omitted, defaults to the manager used to run `create-contentful-app`.
-
-Both flags are mutually exclusive.
+Use npm, pnpm, or Yarn to manage dependencies. If omitted, or if more than one flag is passed, will default to the manager used to run `create-contentful-app`.
 
 ### Template
 

--- a/packages/contentful--create-contentful-app/src/analytics.ts
+++ b/packages/contentful--create-contentful-app/src/analytics.ts
@@ -1,11 +1,12 @@
 import { Analytics } from '@segment/analytics-node';
+import type { PackageManager } from './types';
 
 // Public write key scoped to data source
 const SEGMENT_WRITE_KEY = 'IzCq3j4dQlTAgLdMykRW9oBHQKUy1xMm';
 
 interface CCAEventProperties {
   template?: string; // can be example, source, or JS or TS
-  manager: 'npm' | 'yarn';
+  manager: PackageManager;
   interactive: boolean;
 }
 

--- a/packages/contentful--create-contentful-app/src/getTemplateSource.ts
+++ b/packages/contentful--create-contentful-app/src/getTemplateSource.ts
@@ -45,11 +45,10 @@ async function promptExampleSelection(): Promise<string> {
     // get available templates from examples
     const availableTemplates = await getGithubFolderNames();
     // filter out the ignored ones that are listed as templates instead of examples
-    const filteredTemplates = availableTemplates
-      .filter(
-        (template) =>
-          !IGNORED_EXAMPLE_FOLDERS.includes(template as (typeof IGNORED_EXAMPLE_FOLDERS)[number])
-      )
+    const filteredTemplates = availableTemplates.filter(
+      (template) =>
+        !IGNORED_EXAMPLE_FOLDERS.includes(template as (typeof IGNORED_EXAMPLE_FOLDERS)[number])
+    );
     console.log(availableTemplates.length, filteredTemplates.length);
 
     // ask user to select a template from the available examples

--- a/packages/contentful--create-contentful-app/src/template.ts
+++ b/packages/contentful--create-contentful-app/src/template.ts
@@ -36,6 +36,7 @@ function validate(destination: string): void {
 }
 
 function cleanUp(destination: string) {
+  rmIfExists(resolve(destination, 'pnpm-lock.json'));
   rmIfExists(resolve(destination, 'package-lock.json'));
   rmIfExists(resolve(destination, 'yarn.lock'));
 }

--- a/packages/contentful--create-contentful-app/src/types.ts
+++ b/packages/contentful--create-contentful-app/src/types.ts
@@ -1,6 +1,7 @@
 export type CLIOptions = Partial<{
   npm: boolean;
   yarn: boolean;
+  pnpm: boolean;
   javascript: boolean;
   typescript: boolean;
   source: string;
@@ -8,6 +9,8 @@ export type CLIOptions = Partial<{
   function: string | boolean;
   skipUi: boolean;
 }>;
+
+export type PackageManager = 'npm' | 'yarn' | 'pnpm';
 
 export const ContentfulExample = {
   Javascript: 'javascript',

--- a/packages/contentful--create-contentful-app/test/utils.spec.ts
+++ b/packages/contentful--create-contentful-app/test/utils.spec.ts
@@ -7,6 +7,9 @@ import {
   normalizeOptions,
 } from '../src/utils';
 import type { CLIOptions, PackageManager } from '../src/types';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 describe('utils', () => {
   const packageManagers = ['npm', 'pnpm', 'yarn'];
@@ -21,9 +24,6 @@ describe('utils', () => {
       originalCwd = process.cwd();
 
       // Create temporary directory for each test
-      const fs = require('fs');
-      const os = require('os');
-      const path = require('path');
       tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pm-test-'));
       process.chdir(tempDir);
     });
@@ -39,7 +39,6 @@ describe('utils', () => {
       // Restore working directory and cleanup
       process.chdir(originalCwd);
       try {
-        const fs = require('fs');
         fs.rmSync(tempDir, { recursive: true, force: true });
       } catch (error) {
         // Ignore cleanup errors
@@ -48,25 +47,21 @@ describe('utils', () => {
 
     describe('lock file detection', () => {
       it('should detect pnpm from pnpm-lock.yaml', () => {
-        const fs = require('fs');
         fs.writeFileSync('pnpm-lock.yaml', 'lockfileVersion: 5.4');
         expect(detectActivePackageManager()).to.equal('pnpm');
       });
 
       it('should detect yarn from yarn.lock', () => {
-        const fs = require('fs');
         fs.writeFileSync('yarn.lock', '# yarn lockfile v1');
         expect(detectActivePackageManager()).to.equal('yarn');
       });
 
       it('should detect npm from package-lock.json', () => {
-        const fs = require('fs');
         fs.writeFileSync('package-lock.json', '{"lockfileVersion": 2}');
         expect(detectActivePackageManager()).to.equal('npm');
       });
 
       it('should prioritize pnpm-lock.yaml over other lock files', () => {
-        const fs = require('fs');
         fs.writeFileSync('pnpm-lock.yaml', 'lockfileVersion: 5.4');
         fs.writeFileSync('yarn.lock', '# yarn lockfile v1');
         fs.writeFileSync('package-lock.json', '{"lockfileVersion": 2}');
@@ -74,7 +69,6 @@ describe('utils', () => {
       });
 
       it('should prioritize yarn.lock over package-lock.json', () => {
-        const fs = require('fs');
         fs.writeFileSync('yarn.lock', '# yarn lockfile v1');
         fs.writeFileSync('package-lock.json', '{"lockfileVersion": 2}');
         expect(detectActivePackageManager()).to.equal('yarn');
@@ -83,28 +77,24 @@ describe('utils', () => {
 
     describe('package.json packageManager field detection', () => {
       it('should detect pnpm from package.json packageManager field', () => {
-        const fs = require('fs');
         const packageJson = { packageManager: 'pnpm@8.6.0' };
         fs.writeFileSync('package.json', JSON.stringify(packageJson));
         expect(detectActivePackageManager()).to.equal('pnpm');
       });
 
       it('should detect yarn from package.json packageManager field', () => {
-        const fs = require('fs');
         const packageJson = { packageManager: 'yarn@1.22.19' };
         fs.writeFileSync('package.json', JSON.stringify(packageJson));
         expect(detectActivePackageManager()).to.equal('yarn');
       });
 
       it('should detect npm from package.json packageManager field', () => {
-        const fs = require('fs');
         const packageJson = { packageManager: 'npm@9.8.0' };
         fs.writeFileSync('package.json', JSON.stringify(packageJson));
         expect(detectActivePackageManager()).to.equal('npm');
       });
 
       it('should prioritize lock files over package.json packageManager field', () => {
-        const fs = require('fs');
         fs.writeFileSync('yarn.lock', '# yarn lockfile v1');
         const packageJson = { packageManager: 'pnpm@8.6.0' };
         fs.writeFileSync('package.json', JSON.stringify(packageJson));
@@ -141,14 +131,12 @@ describe('utils', () => {
       });
 
       it('should fall back to npm_execpath when package.json is invalid', () => {
-        const fs = require('fs');
         fs.writeFileSync('package.json', 'invalid json');
         process.env.npm_execpath = '/path/to/yarn.js';
         expect(detectActivePackageManager()).to.equal('yarn');
       });
 
       it('should fall back to npm_execpath when package.json has no packageManager field', () => {
-        const fs = require('fs');
         const packageJson = { name: 'test-app', version: '1.0.0' };
         fs.writeFileSync('package.json', JSON.stringify(packageJson));
         process.env.npm_execpath = '/path/to/pnpm.cjs';
@@ -158,7 +146,6 @@ describe('utils', () => {
 
     describe('priority and edge cases', () => {
       it('should prioritize lock files over package.json over npm_execpath', () => {
-        const fs = require('fs');
         fs.writeFileSync('yarn.lock', '# yarn lockfile v1');
         const packageJson = { packageManager: 'pnpm@8.6.0' };
         fs.writeFileSync('package.json', JSON.stringify(packageJson));
@@ -167,7 +154,6 @@ describe('utils', () => {
       });
 
       it('should prioritize package.json over npm_execpath when no lock files exist', () => {
-        const fs = require('fs');
         const packageJson = { packageManager: 'pnpm@8.6.0' };
         fs.writeFileSync('package.json', JSON.stringify(packageJson));
         process.env.npm_execpath = '/path/to/yarn.js';
@@ -228,9 +214,6 @@ describe('utils', () => {
       originalCwd = process.cwd();
 
       // Create temporary directory for each test
-      const fs = require('fs');
-      const os = require('os');
-      const path = require('path');
       tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'normalize-test-'));
       process.chdir(tempDir);
     });
@@ -246,7 +229,6 @@ describe('utils', () => {
       // Restore working directory and cleanup
       process.chdir(originalCwd);
       try {
-        const fs = require('fs');
         fs.rmSync(tempDir, { recursive: true, force: true });
       } catch (error) {
         // Ignore cleanup errors
@@ -275,7 +257,6 @@ describe('utils', () => {
       });
 
       it('falls back to detected package manager from lock files', () => {
-        const fs = require('fs');
         fs.writeFileSync('yarn.lock', '# yarn lockfile v1');
 
         const options: CLIOptions = {};
@@ -287,7 +268,6 @@ describe('utils', () => {
       });
 
       it('falls back to detected package manager from package.json', () => {
-        const fs = require('fs');
         const packageJson = { packageManager: 'pnpm@8.6.0' };
         fs.writeFileSync('package.json', JSON.stringify(packageJson));
 

--- a/packages/contentful--create-contentful-app/test/utils.spec.ts
+++ b/packages/contentful--create-contentful-app/test/utils.spec.ts
@@ -1,0 +1,160 @@
+import { expect } from 'chai';
+import {
+  detectActivePackageManager,
+  getNormalizedPackageManager,
+  normalizeOptions,
+} from '../src/utils';
+import type { CLIOptions, PackageManager } from '../src/types';
+
+describe('utils', () => {
+  const packageManagers = ['npm', 'pnpm', 'yarn'];
+
+  describe('detectActivePackageManager', () => {
+    let originalNpmExecpath: string | undefined;
+
+    beforeEach(() => {
+      originalNpmExecpath = process.env.npm_execpath;
+    });
+
+    afterEach(() => {
+      if (originalNpmExecpath) {
+        process.env.npm_execpath = originalNpmExecpath;
+      } else {
+        delete process.env.npm_execpath;
+      }
+    });
+
+    [
+      ['yarn', '/path/to/yarn.js'],
+      ['pnpm', '/path/to/pnpm.cjs'],
+      ['npm', '/path/to/npx-cli.js'],
+      ['npm', '/path/to/npm-cli.js'],
+    ].forEach(([packageManager, npmExecpath]) => {
+      it(`should detect ${packageManager} when npm_execpath contains ${npmExecpath}`, () => {
+        process.env.npm_execpath = npmExecpath;
+        expect(detectActivePackageManager()).to.equal(packageManager);
+      });
+    });
+
+    it('should default to npm when npm_execpath is undefined', () => {
+      delete process.env.npm_execpath;
+      expect(detectActivePackageManager()).to.equal('npm');
+    });
+
+    it('should default to npm when npm_execpath is empty string', () => {
+      process.env.npm_execpath = '';
+      expect(detectActivePackageManager()).to.equal('npm');
+    });
+
+    it('should default to npm for unknown execpath', () => {
+      process.env.npm_execpath = '/path/to/unknown-package-manager.js';
+      expect(detectActivePackageManager()).to.equal('npm');
+    });
+  });
+
+  describe('getNormalizedPackageManager', () => {
+    describe('when no package manager options are provided', () => {
+      packageManagers.forEach((activePackageManager) => {
+        it(`returns ${activePackageManager} when active package manager is ${activePackageManager}`, () => {
+          expect(getNormalizedPackageManager({}, activePackageManager as PackageManager)).to.equal(
+            activePackageManager
+          );
+        });
+      });
+    });
+
+    describe('when yarn option is true', () => {
+      packageManagers.forEach((activePackageManager) => {
+        it(`returns "yarn" when active package manager is ${activePackageManager}`, () => {
+          expect(
+            getNormalizedPackageManager({ yarn: true }, activePackageManager as PackageManager)
+          ).to.equal('yarn');
+        });
+      });
+    });
+
+    describe('when pnpm option is true', () => {
+      packageManagers.forEach((activePackageManager) => {
+        it(`returns "pnpm" when active package manager is ${activePackageManager}`, () => {
+          expect(
+            getNormalizedPackageManager({ pnpm: true }, activePackageManager as PackageManager)
+          ).to.equal('pnpm');
+        });
+      });
+    });
+
+    describe('when npm option is true', () => {
+      packageManagers.forEach((activePackageManager) => {
+        it(`returns "npm" when active package manager is ${activePackageManager}`, () => {
+          expect(
+            getNormalizedPackageManager({ npm: true }, activePackageManager as PackageManager)
+          ).to.equal('npm');
+        });
+      });
+    });
+  });
+
+  describe('normalizeOptions', () => {
+    let originalNpmExecpath: string | undefined;
+
+    beforeEach(() => {
+      originalNpmExecpath = process.env.npm_execpath;
+    });
+
+    afterEach(() => {
+      if (originalNpmExecpath) {
+        process.env.npm_execpath = originalNpmExecpath;
+      } else {
+        delete process.env.npm_execpath;
+      }
+    });
+
+    describe('no package manager options are provided', () => {
+      [
+        ['yarn', '/path/to/yarn.js'],
+        ['pnpm', '/path/to/pnpm.cjs'],
+        ['npm', '/path/to/npx-cli.js'],
+      ].forEach(([activePackageManager, npmExecpath]) => {
+        it(`falls back to ${activePackageManager} when that is the active package manager`, () => {
+          process.env.npm_execpath = npmExecpath;
+          const options: CLIOptions = {};
+          const result = normalizeOptions(options);
+          packageManagers.forEach((packageManager) => {
+            if (packageManager === activePackageManager) {
+              expect(result[activePackageManager]).to.be.true;
+            } else {
+              expect(result[packageManager]).to.be.undefined;
+            }
+          });
+        });
+      });
+    });
+
+    describe('one package manager option is provided', () => {
+      packageManagers.forEach((packageManager) => {
+        it(`selects ${packageManager} when that is the only option provided`, () => {
+          const options: CLIOptions = { [packageManager]: true };
+          const result = normalizeOptions(options);
+          packageManagers.forEach((p) => {
+            if (p === packageManager) {
+              expect(result[p]).to.be.true;
+            } else {
+              expect(result[p]).to.be.undefined;
+            }
+          });
+        });
+      });
+    });
+
+    describe('multiple package manager options are provided', () => {
+      it('falls back to the active package manager', () => {
+        process.env.npm_execpath = '/path/to/yarn.js'; // Sets yarn as the active package manager
+        const options: CLIOptions = { npm: true, pnpm: true };
+        const result = normalizeOptions(options);
+        expect(result.npm).to.be.undefined;
+        expect(result.pnpm).to.be.undefined;
+        expect(result.yarn).to.be.true;
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR adds support for the `--pnpm` CLI option, and [pnpm](https://pnpm.io/) support in general, for the `create-contentful-app` tool. This PR **does not** convert the entire monorepo to use pnpm.

## Why is this needed?

For third party apps using pnpm as a package manager, trying to create Contentful apps with `create-contentful-app` via a custom [npm script](https://docs.npmjs.com/cli/v10/using-npm/scripts) (or any kind of script, really) can end up erroring out when the new app's dependencies are installed because of how different local versions of pnpm and npm are handled.

The commands given in console for installing dependencies, and for creating app definitions, are misleading in this case. There was also some ambiguity and unexpected behavior in the handling of when both `--yarn` and `--npm` flags were passed, and npm would be preferred even if it wasn't the current package manager. With this change, multiple package manager flags are ignored and the currently active package manager will be used; this is the same behavior as omitting a package manager flag at all.

This PR updates all areas that package managers are referenced, including the Segment.io analytics track call. Comprehensive test coverage is provided.