### PR TITLE
feat: support-pnpm-package-manager [ZEND-6808]

### DIFF
--- a/packages/contentful--create-contentful-app/README.md
+++ b/packages/contentful--create-contentful-app/README.md
@@ -30,6 +30,9 @@ npx create-contentful-app <app-name>
 # npm
 npm init contentful-app <app-name>
 
+# pnpm
+pnpm init contentful-app <app-name>
+
 # Yarn
 yarn create contentful-app <app-name>
 ```
@@ -38,11 +41,9 @@ yarn create contentful-app <app-name>
 
 ### Package Manager
 
-`--npm` or `--yarn`
+`--npm` or `--pnpm` or `--yarn`
 
-Use npm or Yarn to manage dependencies. If omitted, defaults to the manager used to run `create-contentful-app`.
-
-Both flags are mutually exclusive.
+Use npm, pnpm, or Yarn to manage dependencies. If omitted, or if more than one flag is passed, will default to the manager used to run `create-contentful-app`.
 
 ### Template
 

--- a/packages/contentful--create-contentful-app/src/analytics.ts
+++ b/packages/contentful--create-contentful-app/src/analytics.ts
@@ -1,11 +1,12 @@
 import { Analytics } from '@segment/analytics-node';
+import type { PackageManager } from './types';
 
 // Public write key scoped to data source
 const SEGMENT_WRITE_KEY = 'IzCq3j4dQlTAgLdMykRW9oBHQKUy1xMm';
 
 interface CCAEventProperties {
   template?: string; // can be example, source, or JS or TS
-  manager: 'npm' | 'yarn';
+  manager: PackageManager;
   interactive: boolean;
 }
 

--- a/packages/contentful--create-contentful-app/src/getTemplateSource.ts
+++ b/packages/contentful--create-contentful-app/src/getTemplateSource.ts
@@ -45,11 +45,10 @@ async function promptExampleSelection(): Promise<string> {
     // get available templates from examples
     const availableTemplates = await getGithubFolderNames();
     // filter out the ignored ones that are listed as templates instead of examples
-    const filteredTemplates = availableTemplates
-      .filter(
-        (template) =>
-          !IGNORED_EXAMPLE_FOLDERS.includes(template as (typeof IGNORED_EXAMPLE_FOLDERS)[number])
-      )
+    const filteredTemplates = availableTemplates.filter(
+      (template) =>
+        !IGNORED_EXAMPLE_FOLDERS.includes(template as (typeof IGNORED_EXAMPLE_FOLDERS)[number])
+    );
     console.log(availableTemplates.length, filteredTemplates.length);
 
     // ask user to select a template from the available examples

--- a/packages/contentful--create-contentful-app/src/template.ts
+++ b/packages/contentful--create-contentful-app/src/template.ts
@@ -36,6 +36,7 @@ function validate(destination: string): void {
 }
 
 function cleanUp(destination: string) {
+  rmIfExists(resolve(destination, 'pnpm-lock.json'));
   rmIfExists(resolve(destination, 'package-lock.json'));
   rmIfExists(resolve(destination, 'yarn.lock'));
 }

--- a/packages/contentful--create-contentful-app/src/types.ts
+++ b/packages/contentful--create-contentful-app/src/types.ts
@@ -1,6 +1,7 @@
 export type CLIOptions = Partial<{
   npm: boolean;
   yarn: boolean;
+  pnpm: boolean;
   javascript: boolean;
   typescript: boolean;
   source: string;
@@ -8,6 +9,8 @@ export type CLIOptions = Partial<{
   function: string | boolean;
   skipUi: boolean;
 }>;
+
+export type PackageManager = 'npm' | 'yarn' | 'pnpm';
 
 export const ContentfulExample = {
   Javascript: 'javascript',

--- a/packages/contentful--create-contentful-app/test/utils.spec.ts
+++ b/packages/contentful--create-contentful-app/test/utils.spec.ts
@@ -1,0 +1,160 @@
+import { expect } from 'chai';
+import {
+  detectActivePackageManager,
+  getNormalizedPackageManager,
+  normalizeOptions,
+} from '../src/utils';
+import type { CLIOptions, PackageManager } from '../src/types';
+
+describe('utils', () => {
+  const packageManagers = ['npm', 'pnpm', 'yarn'];
+
+  describe('detectActivePackageManager', () => {
+    let originalNpmExecpath: string | undefined;
+
+    beforeEach(() => {
+      originalNpmExecpath = process.env.npm_execpath;
+    });
+
+    afterEach(() => {
+      if (originalNpmExecpath) {
+        process.env.npm_execpath = originalNpmExecpath;
+      } else {
+        delete process.env.npm_execpath;
+      }
+    });
+
+    [
+      ['yarn', '/path/to/yarn.js'],
+      ['pnpm', '/path/to/pnpm.cjs'],
+      ['npm', '/path/to/npx-cli.js'],
+      ['npm', '/path/to/npm-cli.js'],
+    ].forEach(([packageManager, npmExecpath]) => {
+      it(`should detect ${packageManager} when npm_execpath contains ${npmExecpath}`, () => {
+        process.env.npm_execpath = npmExecpath;
+        expect(detectActivePackageManager()).to.equal(packageManager);
+      });
+    });
+
+    it('should default to npm when npm_execpath is undefined', () => {
+      delete process.env.npm_execpath;
+      expect(detectActivePackageManager()).to.equal('npm');
+    });
+
+    it('should default to npm when npm_execpath is empty string', () => {
+      process.env.npm_execpath = '';
+      expect(detectActivePackageManager()).to.equal('npm');
+    });
+
+    it('should default to npm for unknown execpath', () => {
+      process.env.npm_execpath = '/path/to/unknown-package-manager.js';
+      expect(detectActivePackageManager()).to.equal('npm');
+    });
+  });
+
+  describe('getNormalizedPackageManager', () => {
+    describe('when no package manager options are provided', () => {
+      packageManagers.forEach((activePackageManager) => {
+        it(`returns ${activePackageManager} when active package manager is ${activePackageManager}`, () => {
+          expect(getNormalizedPackageManager({}, activePackageManager as PackageManager)).to.equal(
+            activePackageManager
+          );
+        });
+      });
+    });
+
+    describe('when yarn option is true', () => {
+      packageManagers.forEach((activePackageManager) => {
+        it(`returns "yarn" when active package manager is ${activePackageManager}`, () => {
+          expect(
+            getNormalizedPackageManager({ yarn: true }, activePackageManager as PackageManager)
+          ).to.equal('yarn');
+        });
+      });
+    });
+
+    describe('when pnpm option is true', () => {
+      packageManagers.forEach((activePackageManager) => {
+        it(`returns "pnpm" when active package manager is ${activePackageManager}`, () => {
+          expect(
+            getNormalizedPackageManager({ pnpm: true }, activePackageManager as PackageManager)
+          ).to.equal('pnpm');
+        });
+      });
+    });
+
+    describe('when npm option is true', () => {
+      packageManagers.forEach((activePackageManager) => {
+        it(`returns "npm" when active package manager is ${activePackageManager}`, () => {
+          expect(
+            getNormalizedPackageManager({ npm: true }, activePackageManager as PackageManager)
+          ).to.equal('npm');
+        });
+      });
+    });
+  });
+
+  describe('normalizeOptions', () => {
+    let originalNpmExecpath: string | undefined;
+
+    beforeEach(() => {
+      originalNpmExecpath = process.env.npm_execpath;
+    });
+
+    afterEach(() => {
+      if (originalNpmExecpath) {
+        process.env.npm_execpath = originalNpmExecpath;
+      } else {
+        delete process.env.npm_execpath;
+      }
+    });
+
+    describe('no package manager options are provided', () => {
+      [
+        ['yarn', '/path/to/yarn.js'],
+        ['pnpm', '/path/to/pnpm.cjs'],
+        ['npm', '/path/to/npx-cli.js'],
+      ].forEach(([activePackageManager, npmExecpath]) => {
+        it(`falls back to ${activePackageManager} when that is the active package manager`, () => {
+          process.env.npm_execpath = npmExecpath;
+          const options: CLIOptions = {};
+          const result = normalizeOptions(options);
+          packageManagers.forEach((packageManager) => {
+            if (packageManager === activePackageManager) {
+              expect(result[activePackageManager]).to.be.true;
+            } else {
+              expect(result[packageManager]).to.be.undefined;
+            }
+          });
+        });
+      });
+    });
+
+    describe('one package manager option is provided', () => {
+      packageManagers.forEach((packageManager) => {
+        it(`selects ${packageManager} when that is the only option provided`, () => {
+          const options: CLIOptions = { [packageManager]: true };
+          const result = normalizeOptions(options);
+          packageManagers.forEach((p) => {
+            if (p === packageManager) {
+              expect(result[p]).to.be.true;
+            } else {
+              expect(result[p]).to.be.undefined;
+            }
+          });
+        });
+      });
+    });
+
+    describe('multiple package manager options are provided', () => {
+      it('falls back to the active package manager', () => {
+        process.env.npm_execpath = '/path/to/yarn.js'; // Sets yarn as the active package manager
+        const options: CLIOptions = { npm: true, pnpm: true };
+        const result = normalizeOptions(options);
+        expect(result.npm).to.be.undefined;
+        expect(result.pnpm).to.be.undefined;
+        expect(result.yarn).to.be.true;
+      });
+    });
+  });
+});


### PR DESCRIPTION
**This PR is based on [this one here](https://github.com/contentful/create-contentful-app/pull/2631), and adds a few changes - mostly around how we will detect the fallback package manager.**

This PR adds support for the `--pnpm` CLI option, and [pnpm](https://pnpm.io/) support in general, for the `create-contentful-app` tool. This PR **does not** convert the entire monorepo to use pnpm.

## Why is this needed?
For third party apps using pnpm as a package manage, trying to create Contentful apps with `create-contentful-app` via a custom [npm script](https://docs.npmjs.com/cli/v10/using-npm/scripts) (or any kind of script, really) can end up erroring out when the new app's dependencies are installed because of how different local versions of pnpm and npm are handled.

The commands given in console for installing dependencies, and for creating app definitions, are misleading in this case. There was also some ambiguity and unexpected behavior in the handling of when both `--yarn` and `--npm` flags were passed, and npm would be preferred even if it wasn't the current package manager. With this change, multiple package manager flags are ignored and the currently active package manager will be used; this is the same behavior as omitting a package manager flag at all.

This PR updates all areas that package managers are referenced, including the Segment.io analytics track call. Comprehensive test coverage is provided.