### PR TITLE
fix: add create-contentful-app release remediation workflow

### DIFF
--- a/.github/workflows/remediate-create-contentful-app-release.yaml
+++ b/.github/workflows/remediate-create-contentful-app-release.yaml
@@ -1,0 +1,23 @@
+name: Remediate create-contentful-app release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  restore-latest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.22.1'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Restore public latest tag
+        run: |
+          npm dist-tag add create-contentful-app@2.0.24 latest
+          npm deprecate create-contentful-app@3.0.0 "Accidental release. Use create-contentful-app@2.0.24 while we correct the release configuration."
+          npm dist-tag ls create-contentful-app
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_REGISTRY_NPMJS_ORG_TOKEN }}


### PR DESCRIPTION
## Summary
- Add a manual remediation workflow that uses the existing npmjs token secret to restore the public `create-contentful-app` dist-tag.
- The workflow moves `latest` back to `create-contentful-app@2.0.24` and deprecates the accidental `3.0.0` release.
- This avoids requiring a local npm owner/admin to run the fix manually.

## Context
- PR #3082 triggered release commit `6729db21`, which published public `create-contentful-app@3.0.0`.
- `create-contentful-app@3.0.0` depends on `@contentful/create-contentful-app@3.0.0`, which is not available from public npm.
- Clean installs of `create-contentful-app@3.0.0` fail with `ETARGET`.

## How to run after merge
1. Open **Actions** → **Remediate create-contentful-app release**.
2. Run the workflow from `main`.
3. Confirm the final `npm dist-tag ls create-contentful-app` output shows `latest: 2.0.24`.

## Test plan
- [x] `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/remediate-create-contentful-app-release.yaml'); puts 'workflow yaml ok'"`
- [x] Confirmed a clean install of the accidental `create-contentful-app@3.0.0` fails because `@contentful/create-contentful-app@3.0.0` is missing from public npm.

Generated with [Codex](https://developers.openai.com/codex) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds a manual remediation workflow that uses the existing npmjs token secret to restore the public create-contentful-app dist-tag, moving latest back to create-contentful-app@2.0.24 and deprecating the accidental 3.0.0 release. This avoids requiring a local npm owner/admin to run the fix manually and addresses the issue where PR #3082 triggered an erroneous release that depends on unavailable private packages.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Introduces a new manual workflow in remediate-create-contentful-app-release.yaml to handle npm dist-tag adjustments and deprecation.</li>

<li>The workflow configures Node.js and uses npm commands to restore the latest tag to 2.0.24 and deprecate version 3.0.0.</li>

<li>Leverages the existing NPM_REGISTRY_REGISTRY_NPMJS_ORG_TOKEN secret for authentication to the npm registry.</li>

</ul>
</details>

</div>