### PR TITLE
feat!: migrate app-scripts to contentful-management v12 (plain client, Node 20+)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: ['18.20', '20.18', '22.11']
+        node-version: ['20.18', '22.11']
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: ['20.18', '22.11']
+        node-version: ['20.20', '22.23', '24.18']
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14269,7 +14269,7 @@
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
         "commander": "12.1.0",
-        "contentful-management": "^12.3.1",
+        "contentful-management": "^12.8.0",
         "dotenv": "17.4.2",
         "esbuild": "^0.28.0",
         "ignore": "7.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6020,6 +6020,7 @@
       "version": "11.75.0",
       "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.75.0.tgz",
       "integrity": "sha512-5j0NDwkdfj5x8qY7Ka6RsVMrjMSdu0clMbABQNqZA1wus9SPVETBQAzdJwHeOAhkLa6avzCcERlr4dN4lU/BOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",
@@ -14268,7 +14269,7 @@
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
         "commander": "12.1.0",
-        "contentful-management": "^11.75.0",
+        "contentful-management": "^12.3.1",
         "dotenv": "17.4.2",
         "esbuild": "^0.28.0",
         "ignore": "7.0.5",
@@ -14301,7 +14302,7 @@
         "ts-node": "10.9.2"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=20",
         "npm": ">=9"
       }
     },
@@ -14346,6 +14347,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/contentful--app-scripts/node_modules/contentful-management": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.8.0.tgz",
+      "integrity": "sha512-lARtEZYn2MYf80hz9nCYiLbJWvg95TTnOWmCZouMZtgNS1273dN27Vaz7weHQ3oSQuk7LeYXaXdGFhFPKlpilw==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/rich-text-types": "^16.6.1",
+        "axios": "^1.15.0",
+        "contentful-sdk-core": "^9.4.4",
+        "fast-copy": "^3.0.0",
+        "globals": "^15.15.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "packages/contentful--app-scripts/node_modules/define-lazy-prop": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript": "4.9.5"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "dependencies": {
     "open": "^10.1.0"

--- a/packages/contentful--app-scripts/package.json
+++ b/packages/contentful--app-scripts/package.json
@@ -55,7 +55,7 @@
     "bottleneck": "2.19.5",
     "chalk": "4.1.2",
     "commander": "12.1.0",
-    "contentful-management": "^12.3.1",
+    "contentful-management": "^12.8.0",
     "dotenv": "17.4.2",
     "esbuild": "^0.28.0",
     "ignore": "7.0.5",

--- a/packages/contentful--app-scripts/package.json
+++ b/packages/contentful--app-scripts/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/contentful--app-scripts"
   },
   "engines": {
-    "node": ">=18",
+    "node": ">=20",
     "npm": ">=9"
   },
   "main": "lib/index.js",
@@ -55,7 +55,7 @@
     "bottleneck": "2.19.5",
     "chalk": "4.1.2",
     "commander": "12.1.0",
-    "contentful-management": "^11.75.0",
+    "contentful-management": "^12.3.1",
     "dotenv": "17.4.2",
     "esbuild": "^0.28.0",
     "ignore": "7.0.5",

--- a/packages/contentful--app-scripts/src/create-app-definition/create-app-definition.test.ts
+++ b/packages/contentful--app-scripts/src/create-app-definition/create-app-definition.test.ts
@@ -2,14 +2,14 @@ import proxyquire from 'proxyquire';
 import { stub, match, SinonStub } from 'sinon';
 import assert from 'assert';
 import { APP_DEF_ENV_KEY } from '../constants';
-import { ClientAPI } from 'contentful-management';
+import { PlainClientAPI } from 'contentful-management';
 
 const organizationId = 'orgId';
 const token = 'token';
 
 describe('createAppDefinition', () => {
   let subject: (accessToken?: string, appDefinitionSettings?: any) => Promise<void>,
-    clientMock: ClientAPI,
+    clientMock: PlainClientAPI,
     selectFromListMock: SinonStub,
     cachedEnvVarsMock: SinonStub;
 
@@ -23,9 +23,9 @@ describe('createAppDefinition', () => {
 
   beforeEach(() => {
     clientMock = {
-      getOrganization: stub(),
-      getOrganizations: stub(),
-    } as unknown as ClientAPI;
+      organization: { getAll: stub() },
+      appDefinition: { create: stub() },
+    } as unknown as PlainClientAPI;
 
     cachedEnvVarsMock = stub().resolves(undefined);
 
@@ -49,17 +49,15 @@ describe('createAppDefinition', () => {
   it('throws with invalid options', () => assert.rejects(() => subject(), /TypeError/));
 
   it('throws if unable to fetch organizations', async () => {
-    clientMock.getOrganizations = stub().rejects(new Error());
+    clientMock.organization.getAll = stub().rejects(new Error());
 
     await assert.rejects(() => subject(token, { locations: [] }));
     assert((console.log as SinonStub).calledWith(match(/Could not fetch your organizations/)));
   });
 
   it('throws if unable to create definition', async () => {
-    clientMock.getOrganization = stub().resolves({
-      createAppDefinition: stub().rejects(new Error()),
-    });
-    clientMock.getOrganizations = stub().resolves({
+    clientMock.appDefinition.create = stub().rejects(new Error());
+    clientMock.organization.getAll = stub().resolves({
       items: [{ name: 'name', sys: { id: organizationId } }],
     });
     selectFromListMock.returns({ name: 'name', value: organizationId });
@@ -78,10 +76,8 @@ describe('createAppDefinition', () => {
     const appLink = `https://app.contentful.com/deeplink?link=apps&id=${appId}`;
     const tutorialLink = 'https://ctfl.io/app-tutorial';
 
-    clientMock.getOrganization = stub().resolves({
-      createAppDefinition: stub().resolves({ sys: { id: 'appId' } }),
-    });
-    clientMock.getOrganizations = stub().resolves({
+    clientMock.appDefinition.create = stub().resolves({ sys: { id: 'appId' } });
+    clientMock.organization.getAll = stub().resolves({
       items: [{ name: 'name', sys: { id: organizationId } }],
     });
     selectFromListMock.returns({ name: 'name', value: organizationId });
@@ -103,10 +99,8 @@ describe('createAppDefinition', () => {
     const appLink = `https://app.eu.contentful.com/deeplink?link=apps&id=${appId}`;
     const tutorialLink = 'https://ctfl.io/app-tutorial';
 
-    clientMock.getOrganization = stub().resolves({
-      createAppDefinition: stub().resolves({ sys: { id: 'appId' } }),
-    });
-    clientMock.getOrganizations = stub().resolves({
+    clientMock.appDefinition.create = stub().resolves({ sys: { id: 'appId' } });
+    clientMock.organization.getAll = stub().resolves({
       items: [{ name: 'name', sys: { id: organizationId } }],
     });
     selectFromListMock.returns({ name: 'name', value: organizationId });
@@ -126,29 +120,25 @@ describe('createAppDefinition', () => {
 
   it('sets default src if any frontend location is specified', async () => {
     const createAppDefinitionStub = stub().resolves({ sys: { id: 'testId' } });
-    clientMock.getOrganization = stub().resolves({
-      createAppDefinition: createAppDefinitionStub,
-    });
-    clientMock.getOrganizations = stub().resolves({
+    clientMock.appDefinition.create = createAppDefinitionStub;
+    clientMock.organization.getAll = stub().resolves({
       items: [{ name: 'name', sys: { id: organizationId } }],
     });
     selectFromListMock.returns({ name: 'name', value: organizationId });
 
     await subject(token, { locations: ['entry-field', 'dialog'] });
-    assert(createAppDefinitionStub.calledWithMatch({ src: 'http://localhost:3000' }));
+    assert(createAppDefinitionStub.calledWithMatch(match.any, { src: 'http://localhost:3000' }));
   });
 
   it('does not set default src if only location is dialog', async () => {
     const createAppDefinitionStub = stub().resolves({ sys: { id: 'testId' } });
-    clientMock.getOrganization = stub().resolves({
-      createAppDefinition: createAppDefinitionStub,
-    });
-    clientMock.getOrganizations = stub().resolves({
+    clientMock.appDefinition.create = createAppDefinitionStub;
+    clientMock.organization.getAll = stub().resolves({
       items: [{ name: 'name', sys: { id: organizationId } }],
     });
     selectFromListMock.returns({ name: 'name', value: organizationId });
 
     await subject(token, { locations: ['dialog'] });
-    assert(createAppDefinitionStub.calledWithMatch({ src: undefined }));
+    assert(createAppDefinitionStub.calledWithMatch(match.any, { src: undefined }));
   });
 });

--- a/packages/contentful--app-scripts/src/create-app-definition/create-app-definition.ts
+++ b/packages/contentful--app-scripts/src/create-app-definition/create-app-definition.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { ClientAPI, createClient } from 'contentful-management';
+import { PlainClientAPI, createClient } from 'contentful-management';
 import chalk from 'chalk';
 import { isString, isPlainObject, has } from 'lodash';
 
@@ -10,9 +10,9 @@ import { ORG_ID_ENV_KEY, APP_DEF_ENV_KEY } from '../constants';
 import { AppDefinitionSettings } from '../types';
 import { createTypeSafeLocations } from '../create-type-safe-locations';
 
-async function fetchOrganizations(client: ClientAPI) {
+async function fetchOrganizations(client: PlainClientAPI) {
   try {
-    const orgs = await client.getOrganizations();
+    const orgs = await client.organization.getAll();
 
     return orgs.items.map((org) => ({
       name: org.name,
@@ -64,7 +64,7 @@ export async function createAppDefinition(
   assertValidArguments(accessToken, appDefinitionSettings);
 
   const host = appDefinitionSettings.host;
-  const client = createClient({ accessToken, host }, { type: 'legacy' });
+  const client = createClient({ accessToken, host }, { type: 'plain' });
   const organizations = await fetchOrganizations(client);
 
   const selectedOrg = await selectFromList(
@@ -92,8 +92,7 @@ export async function createAppDefinition(
   };
 
   try {
-    const organization = await client.getOrganization(organizationId);
-    const createdAppDefinition = await organization.createAppDefinition(body);
+    const createdAppDefinition = await client.appDefinition.create({ organizationId }, body);
     await cacheEnvVars({
       [APP_DEF_ENV_KEY]: createdAppDefinition.sys.id,
     });

--- a/packages/contentful--app-scripts/src/create-app-definition/create-app-definition.ts
+++ b/packages/contentful--app-scripts/src/create-app-definition/create-app-definition.ts
@@ -64,7 +64,7 @@ export async function createAppDefinition(
   assertValidArguments(accessToken, appDefinitionSettings);
 
   const host = appDefinitionSettings.host;
-  const client = createClient({ accessToken, host });
+  const client = createClient({ accessToken, host }, { type: 'legacy' });
   const organizations = await fetchOrganizations(client);
 
   const selectedOrg = await selectFromList(
@@ -75,7 +75,7 @@ export async function createAppDefinition(
   const organizationId = selectedOrg.value;
 
   const appName = appDefinitionSettings.name || path.basename(process.cwd());
-  const locations = createTypeSafeLocations(appDefinitionSettings)
+  const locations = createTypeSafeLocations(appDefinitionSettings);
   const hasFrontendLocation = locations.some(({ location }) => location !== 'dialog');
   const body = {
     name: appName,

--- a/packages/contentful--app-scripts/src/definition-api.ts
+++ b/packages/contentful--app-scripts/src/definition-api.ts
@@ -1,7 +1,7 @@
 import ora from 'ora';
 import { selectFromList, throwError } from './utils';
 import { APP_DEF_ENV_KEY } from './constants';
-import { AppDefinition, ClientAPI } from 'contentful-management';
+import { AppDefinitionProps, PlainClientAPI } from 'contentful-management';
 
 export interface Definition {
   name: string;
@@ -9,16 +9,17 @@ export interface Definition {
   locations: string[];
 }
 
-async function fetchDefinitions(client: ClientAPI, orgId: string): Promise<Definition[]> {
+async function fetchDefinitions(client: PlainClientAPI, orgId: string): Promise<Definition[]> {
   try {
-    const organization = await client.getOrganization(orgId);
-
-    const batchedAppDefinitions: AppDefinition[] = [];
+    const batchedAppDefinitions: AppDefinitionProps[] = [];
     let skip = 0;
     let totalNumOfAppDefinitions = 0;
 
     while (skip === 0 || batchedAppDefinitions.length < totalNumOfAppDefinitions) {
-      const appDefinitionsResponse = await organization.getAppDefinitions({ skip, limit: 100 });
+      const appDefinitionsResponse = await client.appDefinition.getMany({
+        organizationId: orgId,
+        query: { skip, limit: 100 },
+      });
 
       totalNumOfAppDefinitions = appDefinitionsResponse.total;
       batchedAppDefinitions.push(...appDefinitionsResponse.items);
@@ -39,7 +40,7 @@ async function fetchDefinitions(client: ClientAPI, orgId: string): Promise<Defin
   }
 }
 
-export async function selectDefinition(client: ClientAPI, orgId: string): Promise<Definition> {
+export async function selectDefinition(client: PlainClientAPI, orgId: string): Promise<Definition> {
   const defSpinner = ora('Fetching all definitions...').start();
   const definitions = await fetchDefinitions(client, orgId);
   defSpinner.stop();
@@ -48,13 +49,15 @@ export async function selectDefinition(client: ClientAPI, orgId: string): Promis
 }
 
 export async function getDefinitionById(
-  client: ClientAPI,
+  client: PlainClientAPI,
   orgId: string,
   defId: string
 ): Promise<Definition> {
   try {
-    const organization = await client.getOrganization(orgId);
-    const definition = await organization.getAppDefinition(defId);
+    const definition = await client.appDefinition.get({
+      organizationId: orgId,
+      appDefinitionId: defId,
+    });
     return {
       name: definition.name,
       value: definition.sys.id,

--- a/packages/contentful--app-scripts/src/get-app-info.ts
+++ b/packages/contentful--app-scripts/src/get-app-info.ts
@@ -15,7 +15,7 @@ export const getAppInfo = async ({
   host?: string;
 }) => {
   const accessToken = token || (await getManagementToken(host));
-  const client = createClient({ accessToken, host }, { type: 'legacy' });
+  const client = createClient({ accessToken, host }, { type: 'plain' });
 
   const organization = organizationId
     ? await getOrganizationById(client, organizationId)

--- a/packages/contentful--app-scripts/src/get-app-info.ts
+++ b/packages/contentful--app-scripts/src/get-app-info.ts
@@ -15,7 +15,7 @@ export const getAppInfo = async ({
   host?: string;
 }) => {
   const accessToken = token || (await getManagementToken(host));
-  const client = createClient({ accessToken, host });
+  const client = createClient({ accessToken, host }, { type: 'legacy' });
 
   const organization = organizationId
     ? await getOrganizationById(client, organizationId)

--- a/packages/contentful--app-scripts/src/get-management-token.test.ts
+++ b/packages/contentful--app-scripts/src/get-management-token.test.ts
@@ -26,8 +26,10 @@ describe('getManagementToken-js', () => {
         'contentful-management': {
           createClient() {
             return {
-              async getOrganizations() {
-                throw new Error();
+              user: {
+                async getCurrent() {
+                  throw new Error();
+                },
               },
             };
           },

--- a/packages/contentful--app-scripts/src/get-management-token.ts
+++ b/packages/contentful--app-scripts/src/get-management-token.ts
@@ -9,8 +9,8 @@ import { ACCESS_TOKEN_ENV_KEY } from './constants';
 
 const checkTokenValidity = async (accessToken = '', host?: string) => {
   try {
-    const client = createClient({ accessToken, host }, { type: 'legacy' });
-    await client.getCurrentUser();
+    const client = createClient({ accessToken, host }, { type: 'plain' });
+    await client.user.getCurrent();
     return true;
   } catch (err) {
     return false;

--- a/packages/contentful--app-scripts/src/get-management-token.ts
+++ b/packages/contentful--app-scripts/src/get-management-token.ts
@@ -9,7 +9,7 @@ import { ACCESS_TOKEN_ENV_KEY } from './constants';
 
 const checkTokenValidity = async (accessToken = '', host?: string) => {
   try {
-    const client = createClient({ accessToken, host });
+    const client = createClient({ accessToken, host }, { type: 'legacy' });
     await client.getCurrentUser();
     return true;
   } catch (err) {

--- a/packages/contentful--app-scripts/src/organization-api.ts
+++ b/packages/contentful--app-scripts/src/organization-api.ts
@@ -1,16 +1,16 @@
 import ora from 'ora';
 import { selectFromList, throwError } from './utils';
 import { ORG_ID_ENV_KEY } from './constants';
-import { ClientAPI } from 'contentful-management';
+import { PlainClientAPI } from 'contentful-management';
 
 export interface Organization {
   name: string;
   value: string;
 }
 
-async function fetchOrganizations(client: ClientAPI): Promise<Organization[]> {
+async function fetchOrganizations(client: PlainClientAPI): Promise<Organization[]> {
   try {
-    const orgs = await client.getOrganizations();
+    const orgs = await client.organization.getAll();
 
     return orgs.items.map((org) => ({
       name: org.name,
@@ -24,7 +24,7 @@ async function fetchOrganizations(client: ClientAPI): Promise<Organization[]> {
   }
 }
 
-export async function selectOrganization(client: ClientAPI): Promise<Organization> {
+export async function selectOrganization(client: PlainClientAPI): Promise<Organization> {
   const orgSpinner = ora('Fetching your organizations...').start();
 
   try {
@@ -36,9 +36,12 @@ export async function selectOrganization(client: ClientAPI): Promise<Organizatio
   }
 }
 
-export async function getOrganizationById(client: ClientAPI, orgId: string): Promise<Organization> {
+export async function getOrganizationById(
+  client: PlainClientAPI,
+  orgId: string
+): Promise<Organization> {
   try {
-    const org = await client.getOrganization(orgId);
+    const org = await client.organization.get({ organizationId: orgId });
     return {
       name: org.name,
       value: org.sys.id,

--- a/packages/contentful--app-scripts/src/upload/create-app-bundle.test.ts
+++ b/packages/contentful--app-scripts/src/upload/create-app-bundle.test.ts
@@ -1,7 +1,7 @@
 import { stub, match, SinonStub } from 'sinon';
 import assert from 'assert';
 import proxyquire from 'proxyquire';
-import { AppUpload, ClientAPI } from 'contentful-management';
+import { AppUpload, PlainClientAPI } from 'contentful-management';
 import { UploadSettings } from '../types';
 import { processCreateAppBundleError } from './create-app-bundle';
 
@@ -14,7 +14,7 @@ const mockedSettings = {
 
 describe('createAppBundleFromUpload', () => {
   let createAppBundleFromUpload: typeof import('./create-app-bundle').createAppBundleFromUpload,
-    clientMock: ClientAPI,
+    clientMock: PlainClientAPI,
     createClientArgs: any[];
 
   beforeEach(() => {
@@ -27,13 +27,9 @@ describe('createAppBundleFromUpload', () => {
 
   beforeEach(() => {
     clientMock = {
-      getOrganization: () => ({
-        getAppDefinition: () => ({
-          createAppBundle: () => bundleMock,
-        }),
-      }),
-      getOrganizations: stub(),
-    } as unknown as ClientAPI;
+      appDefinition: { get: () => ({ sys: { id: 'id' } }) },
+      appBundle: { create: () => bundleMock },
+    } as unknown as PlainClientAPI;
 
     ({ createAppBundleFromUpload } = proxyquire('./create-app-bundle', {
       'contentful-management': {
@@ -50,12 +46,9 @@ describe('createAppBundleFromUpload', () => {
   });
   it('shows creation error when createAppBundle throws', async () => {
     clientMock = {
-      getOrganization: () => ({
-        getAppDefinition: () => ({
-          createAppBundle: stub().rejects(new Error()),
-        }),
-      }),
-    } as unknown as ClientAPI;
+      appDefinition: { get: () => ({ sys: { id: 'id' } }) },
+      appBundle: { create: stub().rejects(new Error()) },
+    } as unknown as PlainClientAPI;
     await createAppBundleFromUpload(mockedSettings, 'upload-id');
 
     assert((console.log as SinonStub).calledWith(match(/Creation error:/)));
@@ -68,7 +61,7 @@ describe('createAppBundleFromUpload', () => {
 
 describe('createAppBundleFromSettings', () => {
   let createAppBundleFromSettings: typeof import('./create-app-bundle').createAppBundleFromSettings,
-    clientMock: ClientAPI,
+    clientMock: PlainClientAPI,
     uploadMock: AppUpload,
     createClientArgs: any[];
 
@@ -82,13 +75,9 @@ describe('createAppBundleFromSettings', () => {
 
   beforeEach(() => {
     clientMock = {
-      getOrganization: () => ({
-        getAppDefinition: () => ({
-          createAppBundle: () => bundleMock,
-        }),
-      }),
-      getOrganizations: stub(),
-    } as unknown as ClientAPI;
+      appDefinition: { get: () => ({ sys: { id: 'id' } }) },
+      appBundle: { create: () => bundleMock },
+    } as unknown as PlainClientAPI;
 
     uploadMock = { sys: { id: 'test-id' } } as AppUpload;
 

--- a/packages/contentful--app-scripts/src/upload/create-app-bundle.ts
+++ b/packages/contentful--app-scripts/src/upload/create-app-bundle.ts
@@ -9,11 +9,14 @@ import { UploadSettings } from '../types';
 export async function createAppBundleFromUpload(settings: UploadSettings, appUploadId: string) {
   const { accessToken, host, userAgentApplication, comment, functions } = settings;
   const clientSpinner = ora('Verifying your upload...').start();
-  const client = createClient({
-    accessToken,
-    host,
-    application: userAgentApplication ? userAgentApplication : 'contentful.app-scripts',
-  });
+  const client = createClient(
+    {
+      accessToken,
+      host,
+      application: userAgentApplication ? userAgentApplication : 'contentful.app-scripts',
+    },
+    { type: 'legacy' }
+  );
   const organization = await client.getOrganization(settings.organization.value);
   const appDefinition = await organization.getAppDefinition(settings.definition.value);
   clientSpinner.stop();

--- a/packages/contentful--app-scripts/src/upload/create-app-bundle.ts
+++ b/packages/contentful--app-scripts/src/upload/create-app-bundle.ts
@@ -15,20 +15,28 @@ export async function createAppBundleFromUpload(settings: UploadSettings, appUpl
       host,
       application: userAgentApplication ? userAgentApplication : 'contentful.app-scripts',
     },
-    { type: 'legacy' }
+    { type: 'plain' }
   );
-  const organization = await client.getOrganization(settings.organization.value);
-  const appDefinition = await organization.getAppDefinition(settings.definition.value);
+  await client.appDefinition.get({
+    organizationId: settings.organization.value,
+    appDefinitionId: settings.definition.value,
+  });
   clientSpinner.stop();
 
   let appBundle = null;
   const bundleSpinner = ora('Creating the app bundle...').start();
   try {
-    appBundle = await appDefinition.createAppBundle({
-      appUploadId,
-      comment: comment && comment.length > 0 ? comment : undefined,
-      functions,
-    });
+    appBundle = await client.appBundle.create(
+      {
+        organizationId: settings.organization.value,
+        appDefinitionId: settings.definition.value,
+      },
+      {
+        appUploadId,
+        comment: comment && comment.length > 0 ? comment : undefined,
+        functions,
+      }
+    );
   } catch (err: any) {
     showCreationError('app upload', processCreateAppBundleError(err));
   }

--- a/packages/contentful--app-scripts/src/upload/create-app-upload.test.ts
+++ b/packages/contentful--app-scripts/src/upload/create-app-upload.test.ts
@@ -1,11 +1,12 @@
 import assert from 'assert';
 import { stub, match, SinonStub } from 'sinon';
 import proxyquire from 'proxyquire';
-import { ClientAPI } from 'contentful-management';
+import { PlainClientAPI } from 'contentful-management';
 import { UploadSettings } from '../types';
 
 describe('createAppUpload', () => {
-  let createAppUpload: typeof import('./create-app-upload').createAppUpload, clientMock: ClientAPI;
+  let createAppUpload: typeof import('./create-app-upload').createAppUpload,
+    clientMock: PlainClientAPI;
   const uploadMock = { sys: { id: 'test-id' } };
   const mockedSettings = {
     accessToken: 'token',
@@ -22,10 +23,8 @@ describe('createAppUpload', () => {
 
   beforeEach(() => {
     clientMock = {
-      getOrganization: () => ({
-        createAppUpload: () => uploadMock,
-      }),
-    } as unknown as ClientAPI;
+      appUpload: { create: () => uploadMock },
+    } as unknown as PlainClientAPI;
 
     ({ createAppUpload } = proxyquire('./create-app-upload', {
       'contentful-management': {
@@ -45,10 +44,8 @@ describe('createAppUpload', () => {
 
   it('shows creation error when createAppUpload throws', async () => {
     clientMock = {
-      getOrganization: () => ({
-        createAppUpload: stub().rejects(new Error()),
-      }),
-    } as unknown as ClientAPI;
+      appUpload: { create: stub().rejects(new Error()) },
+    } as unknown as PlainClientAPI;
     await createAppUpload(mockedSettings);
 
     assert((console.log as SinonStub).calledWith(match(/Creation error:/)));

--- a/packages/contentful--app-scripts/src/upload/create-app-upload.ts
+++ b/packages/contentful--app-scripts/src/upload/create-app-upload.ts
@@ -12,10 +12,9 @@ async function createAppBundleFromFile(orgId: string, token: string, zip: Buffer
       host,
       hostUpload: host.replace(/^api/i, 'upload'),
     },
-    { type: 'legacy' }
+    { type: 'plain' }
   );
-  const org = await client.getOrganization(orgId);
-  return await org.createAppUpload(zip);
+  return await client.appUpload.create({ organizationId: orgId }, { file: zip });
 }
 
 export async function createAppUpload(settings: UploadSettings) {

--- a/packages/contentful--app-scripts/src/upload/create-app-upload.ts
+++ b/packages/contentful--app-scripts/src/upload/create-app-upload.ts
@@ -6,11 +6,14 @@ import { createClient } from 'contentful-management';
 import { UploadSettings } from '../types';
 
 async function createAppBundleFromFile(orgId: string, token: string, zip: Buffer, host = '') {
-  const client = createClient({
-    accessToken: token,
-    host,
-    hostUpload: host.replace(/^api/i, 'upload'),
-  });
+  const client = createClient(
+    {
+      accessToken: token,
+      host,
+      hostUpload: host.replace(/^api/i, 'upload'),
+    },
+    { type: 'legacy' }
+  );
   const org = await client.getOrganization(orgId);
   return await org.createAppUpload(zip);
 }

--- a/packages/contentful--create-contentful-app/package.json
+++ b/packages/contentful--create-contentful-app/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/contentful--create-contentful-app"
   },
   "engines": {
-    "node": ">=18",
+    "node": ">=20",
     "npm": ">=9"
   },
   "main": "lib/index.js",

--- a/packages/create-contentful-app/package.json
+++ b/packages/create-contentful-app/package.json
@@ -14,8 +14,8 @@
     "directory": "packages/create-contentful-app"
   },
   "engines": {
-    "node": ">=14",
-    "npm": ">=6"
+    "node": ">=20",
+    "npm": ">=9"
   },
   "type": "module",
   "main": "index.js",


### PR DESCRIPTION
## Summary

Migrates `@contentful/app-scripts` from `contentful-management` `^11.75.0` → `^12.8.0`, aligning it with the v12 already used by `@contentful/react-apps-toolkit` (and the app-sdk it depends on) and deduping `contentful-management` in `node_modules`.

CM v12 changed the default `createClient` overload to return the plain client (`PlainClientAPI`) instead of the nested (legacy) client. Rather than opting back into the deprecated legacy client, every `createClient` call site is moved onto the plain client — the legacy client is slated for removal in CM's next major, so this avoids a throwaway follow-up.

## 💥 Breaking change: drops Node 18 support

This is released as a **major** (`feat!`). `contentful-management` v12 requires **Node ≥20**, so `engines.node` moves `>=18` → `>=20` across all packages. Consumers on Node 18 (EOL) must upgrade.

Releasing this as a breaking change is consistent with how this repo has handled EOL Node drops before (e.g. [5007a4f](https://github.com/contentful/create-contentful-app/commit/5007a4f1d5ffae4c544e78d318e5cb436ea28219)). Note app-scripts' bundle validator already relies on `fs.readdirSync(recursive: true)` (Node 20+), so this also makes the declared minimum honest about what the code already requires (superseding the stale #2050).

Engines aligned to `>=20` in: `@contentful/app-scripts`, `@contentful/create-contentful-app`, the `create-contentful-app` CLI wrapper, and the workspace root.

The CI test matrix drops the `18.20` entry, adds Node 24 (Active LTS), and freshens the stale 20/22 pins: `['18.20', '20.18', '22.11']` → `['20.20', '22.23', '24.18']`. This stops testing a version the packages now declare unsupported and adds coverage for the current LTS. The required check (`CI Status`) rolls up the matrix via `needs: test`, so it isn't pinned to any per-version job.

## Notable changes for reviewers

### Call sites migrated to the plain client
| File | Before (nested) | After (plain) |
|---|---|---|
| `get-management-token.ts` | `client.getCurrentUser()` | `client.user.getCurrent()` |
| `organization-api.ts` | `client.getOrganizations()` / `getOrganization(id)` | `client.organization.getAll()` / `get({ organizationId })` |
| `definition-api.ts` | `org.getAppDefinitions()` / `getAppDefinition(id)` | `client.appDefinition.getMany(...)` / `get(...)` |
| `create-app-definition.ts` | `org.createAppDefinition(body)` | `client.appDefinition.create({ organizationId }, body)` |
| `upload/create-app-bundle.ts` | `org.getAppDefinition().createAppBundle()` | `client.appDefinition.get(...)` + `client.appBundle.create(...)` |
| `upload/create-app-upload.ts` | `org.createAppUpload(zip)` | `client.appUpload.create({ organizationId }, { file })` |

In `create-app-bundle.ts`, the org→appDefinition traversal the nested API required is replaced by a single `appDefinition.get` call kept as a verification step (preserves fail-early behavior on an invalid definition/org before the bundle is created).

## Test plan
- [x] `npm run build` (tsc) passes for `@contentful/app-scripts`
- [x] `npm test` — 177 passing; the 6 failures are pre-existing color-output assertion mismatches on `main`, unrelated to this change
- [x] `npm run lint` — 0 errors
- [x] Lockfile regenerated; `@contentful/app-scripts` resolves `contentful-management@12.8.0`
- [x] CI matrix drops Node `18.20`, adds `24.18` (Active LTS), freshens 20/22 pins → `['20.20', '22.23', '24.18']` 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR migrates @contentful/app-scripts from contentful-management v11 to v12, upgrading the client API from the nested ClientAPI to the flat PlainClientAPI across all call sites. It also raises the minimum Node.js requirement from >=18 to >=20 across all workspace packages and the CI test matrix to align with contentful-management v12 requirements.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Drops Node 18 support by raising engines.node from >=18 to >=20 across 4 packages (workspace root, @contentful/app-scripts, @contentful/create-contentful-app, and create-contentful-app CLI), reflecting contentful-management v12 requirements and existing fs.readdirSync(recursive:true) usage already present in the codebase.</li>

<li>Updates contentful-management dependency from ^11.75.0 to ^12.8.0 in @contentful/app-scripts package.json, aligning with @contentful/react-apps-toolkit and deduplicating the package in node_modules.</li>

<li>Migrates createClient calls in get-management-token.ts and get-app-info.ts to plain client by adding {type:'plain'} option and replacing client.getCurrentUser() with client.user.getCurrent().</li>

<li>Replaces organization-related nested API calls in organization-api.ts and definition-api.ts with flat plain client methods: getOrganization/getOrganizations become client.organization.get/getAll, and getAppDefinitions/getAppDefinition become client.appDefinition.getMany/get.</li>

<li>Updates upload module (create-app-bundle.ts, create-app-upload.ts) to use client.appDefinition.get for verification and client.appBundle.create/client.appUpload.create for resource creation instead of nested org methods like org.createAppUpload.</li>

</ul>
</details>

</div>