### PR TITLE
chore: scope nx release bumps to packages with dependency changes

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,10 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "pluginsConfig": {
+    "@nx/js": {
+      "projectsAffectedByDependencyUpdates": "auto"
+    }
+  },
   "tasksRunnerOptions": {
     "default": {
       "runner": "nx/tasks-runners/default",


### PR DESCRIPTION
## Summary

The `@nx/js` plugin defaults [`projectsAffectedByDependencyUpdates`](https://nx.dev/reference/nx-json) to `"all"`, which treats **any** change to the root `package-lock.json` as affecting **every** project in the workspace.

Because releases here use independent, conventional-commit versioning (`nx release`), a single commit that also updates the lockfile is attributed to all packages. As a result, a breaking change in one package can bump unrelated, unmodified packages to a new major — producing releases whose only changelog entry is "this was a version bump only … there were no code changes."

This sets `projectsAffectedByDependencyUpdates` to `"auto"`, which scopes dependency-update detection to packages whose own manifest or source actually changed. For npm (`package-lock.json`), lockfile-only churn no longer marks packages as affected. Packages continue to version correctly from their own `package.json`/source changes (for example, Dependabot bumps still produce the expected per-package patch); only the workspace-wide propagation via the lockfile is removed.

This is a release-tooling configuration change only — no package source or public API is affected, and it does not itself trigger a release.

## Verification

Simulated a squash merge of a breaking change onto `main` and compared `nx release --dry-run` output:

| Package | Before (`"all"`) | After (`"auto"`) |
|---|---|---|
| package with the breaking change | major | major |
| packages with their own manifest changes | major | major |
| unrelated, unmodified package | **major (empty changelog)** | **no release** |

After the change, only packages that actually changed are versioned; the unmodified package reports "No changes were detected" and is skipped. `nx release publish --dry-run` behavior is otherwise unchanged.

## Test plan

- [ ] CI green
- [ ] Confirm the next release only versions packages with real changes (watch the release job's dry-run/version summary on the following merge)

Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)