### PR TITLE
feat(create-contentful-app): install app-building AI skill on scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ dist
 .vscode
 .parcel-cache
 .history
+
+.vbw-planning/

--- a/packages/contentful--create-contentful-app/README.md
+++ b/packages/contentful--create-contentful-app/README.md
@@ -56,6 +56,20 @@ Select between predefined and custom templates:
 
 These flags are mutually exclusive. If no flag is provided, the TypeScript template is used.
 
+### AI App-Building Skill
+
+By default, `create-contentful-app` installs Contentful's official app-building AI skill ([`contentful-custom-app-from-scratch`](https://github.com/contentful/skills)) into your new app. The skill gives AI coding harnesses (Claude Code, OpenAI Codex, Cursor, and others) expert guidance for building Contentful apps. It is pulled live via the [`skills`](https://skills.sh) CLI at scaffold time, so you always get the current version, and the CLI automatically detects your harness.
+
+In interactive mode you are asked whether to include it (default yes). Installation is best-effort: if it fails (e.g. you are offline), your app is still created and a message shows the command to add it later.
+
+- `--skip-skills` (or `--no-skills`): do not install the app-building skill.
+
+To install it manually later, run this inside your app folder:
+
+```bash
+npx skills add contentful/skills --skill contentful-custom-app-from-scratch
+```
+
 Some popular templates are:
 
 | Template                                                                         | CLI Command                                       |
@@ -98,6 +112,8 @@ Options:
                                                 format: URL (HTTPS or SSH) or vendor:user/repo (e.g., github:user/repo)
   -f, --function <function-template-name>       include the specified function template
   --skip-ui                                     use with --function to clone the template without a user interface (UI).
+  --skip-skills                                 skip installing the Contentful app-building AI skill into the new app
+  --no-skills                                   alias for --skip-skills
   -h, --help                                    shows all available CLI options
 ```
 

--- a/packages/contentful--create-contentful-app/README.md
+++ b/packages/contentful--create-contentful-app/README.md
@@ -67,7 +67,7 @@ In interactive mode you are asked whether to include it (default yes). Installat
 To install it manually later, run this inside your app folder:
 
 ```bash
-npx skills add contentful/skills --skill contentful-custom-app-from-scratch
+npx -y skills add contentful/skills --skill contentful-custom-app-from-scratch -y
 ```
 
 Some popular templates are:

--- a/packages/contentful--create-contentful-app/src/index.ts
+++ b/packages/contentful--create-contentful-app/src/index.ts
@@ -19,6 +19,7 @@ import { code, error, highlight, success, warn, wrapInBlanks } from './logger';
 import chalk from 'chalk';
 import { CREATE_APP_DEFINITION_GUIDE_URL, EXAMPLES_REPO_URL } from './constants';
 import { getTemplateSource } from './getTemplateSource';
+import { installAppBuildingSkill, resolveShouldIncludeSkill } from './skills';
 import { track } from './analytics';
 import { generateFunction } from '@contentful/app-scripts';
 import fs from 'fs';
@@ -145,6 +146,21 @@ async function initProject(appName: string, options: CLIOptions) {
     } else {
       await exec('npm', ['install', '--no-audit', '--no-fund'], { cwd: fullAppFolder });
     }
+
+    // Whether the CLI is running without any template-selecting flags. In that
+    // case we prompt about the app-building skill; otherwise we honor the flag.
+    const isInteractiveRun =
+      !normalizedOptions.example &&
+      !normalizedOptions.source &&
+      !normalizedOptions.javascript &&
+      !normalizedOptions.typescript &&
+      !normalizedOptions.function;
+
+    const includeSkill = await resolveShouldIncludeSkill(normalizedOptions, isInteractiveRun);
+    if (includeSkill) {
+      await installAppBuildingSkill(fullAppFolder);
+    }
+
     successMessage(fullAppFolder, packageManager);
   } catch (err) {
     error(`Failed to create ${highlight(chalk.cyan(appName))}`, err);
@@ -245,6 +261,11 @@ async function initProject(appName: string, options: CLIOptions) {
     )
     .option('-f, --function [function-template-name]', 'include the specified function template')
     .option('--skip-ui', 'use with --function to clone the template without a user interface (UI).')
+    .option(
+      '--skip-skills',
+      'skip installing the Contentful app-building AI skill into the new app'
+    )
+    .option('--no-skills', 'alias for --skip-skills')
     .action(initProject);
   await program.parseAsync();
 })();

--- a/packages/contentful--create-contentful-app/src/index.ts
+++ b/packages/contentful--create-contentful-app/src/index.ts
@@ -26,6 +26,20 @@ import fs from 'fs';
 
 const DEFAULT_APP_NAME = 'contentful-app';
 
+/**
+ * Whether the CLI is running without any template-selecting flags. In that case
+ * we prompt the user (e.g. for the app-building skill); otherwise we honor the flags.
+ */
+function isInteractiveRun(options: CLIOptions): boolean {
+  return (
+    !options.example &&
+    !options.source &&
+    !options.javascript &&
+    !options.typescript &&
+    !options.function
+  );
+}
+
 function successMessage(folder: string, packageManager: PackageManager) {
   let command = '';
   if (packageManager === 'yarn') {
@@ -147,16 +161,10 @@ async function initProject(appName: string, options: CLIOptions) {
       await exec('npm', ['install', '--no-audit', '--no-fund'], { cwd: fullAppFolder });
     }
 
-    // Whether the CLI is running without any template-selecting flags. In that
-    // case we prompt about the app-building skill; otherwise we honor the flag.
-    const isInteractiveRun =
-      !normalizedOptions.example &&
-      !normalizedOptions.source &&
-      !normalizedOptions.javascript &&
-      !normalizedOptions.typescript &&
-      !normalizedOptions.function;
-
-    const includeSkill = await resolveShouldIncludeSkill(normalizedOptions, isInteractiveRun);
+    const includeSkill = await resolveShouldIncludeSkill(
+      normalizedOptions,
+      isInteractiveRun(normalizedOptions)
+    );
     if (includeSkill) {
       await installAppBuildingSkill(fullAppFolder);
     }
@@ -168,12 +176,7 @@ async function initProject(appName: string, options: CLIOptions) {
   }
 
   async function addAppExample(fullAppFolder: string) {
-    const isInteractive =
-      !normalizedOptions.example &&
-      !normalizedOptions.source &&
-      !normalizedOptions.javascript &&
-      !normalizedOptions.typescript &&
-      !normalizedOptions.function;
+    const isInteractive = isInteractiveRun(normalizedOptions);
 
     const templateSource = await getTemplateSource(options);
 

--- a/packages/contentful--create-contentful-app/src/skills.ts
+++ b/packages/contentful--create-contentful-app/src/skills.ts
@@ -1,0 +1,109 @@
+import inquirer from 'inquirer';
+import { spawn } from 'child_process';
+import { CLIOptions } from './types';
+import { choice, highlight, success, warn } from './logger';
+
+export const SKILLS_SOURCE = 'contentful/skills';
+export const APP_BUILDING_SKILL = 'contentful-custom-app-from-scratch';
+
+/**
+ * The command a user can run manually to install the skill later. Kept in sync
+ * with the arguments passed to the default runner below.
+ */
+export const MANUAL_INSTALL_COMMAND = `npx skills add ${SKILLS_SOURCE} --skill ${APP_BUILDING_SKILL}`;
+
+/**
+ * Runs the skill installer in the given app folder. Resolves on success and
+ * rejects on failure. Injectable so it can be stubbed in tests.
+ */
+export type SkillRunner = (appFolder: string) => Promise<void>;
+
+const defaultRunner: SkillRunner = (appFolder: string) =>
+  new Promise<void>((resolve, reject) => {
+    const child = spawn(
+      'npx',
+      ['-y', 'skills', 'add', SKILLS_SOURCE, '--skill', APP_BUILDING_SKILL, '-y'],
+      { stdio: 'inherit', shell: true, cwd: appFolder }
+    );
+    child.on('error', reject);
+    child.on('exit', (exitCode) => {
+      if (exitCode === 0) {
+        resolve();
+      } else {
+        reject(new Error(`skills installer exited with code ${exitCode ?? 'unknown'}`));
+      }
+    });
+  });
+
+/**
+ * Best-effort installation of the Contentful app-building skill into a scaffolded
+ * app. The skill is pulled live via the `skills` CLI so it is always current and
+ * works across AI harnesses (Claude Code, OpenAI Codex, Cursor, and others — the
+ * CLI auto-detects the active harness).
+ *
+ * This never throws: a failure (offline, npx error, etc.) is logged as a warning
+ * with the manual command so app creation always completes.
+ *
+ * @returns `true` if the skill was installed, `false` if installation was skipped
+ *          due to an error.
+ */
+export async function installAppBuildingSkill(
+  appFolder: string,
+  deps: { run?: SkillRunner } = {}
+): Promise<boolean> {
+  const run = deps.run ?? defaultRunner;
+
+  console.log(`Installing the Contentful app-building AI skill (${highlight(APP_BUILDING_SKILL)})...`);
+
+  try {
+    await run(appFolder);
+    console.log(`${success('Done!')} Added the ${highlight(APP_BUILDING_SKILL)} skill to your app.`);
+    return true;
+  } catch (e) {
+    warn(
+      `Could not install the Contentful app-building AI skill. Your app was created successfully. ` +
+        `To add it later, run ${choice(MANUAL_INSTALL_COMMAND)} inside your app folder.`
+    );
+    return false;
+  }
+}
+
+/**
+ * Prompts the user (interactive mode only) whether to include the app-building
+ * skill. Defaults to yes.
+ */
+export async function promptIncludeSkill(): Promise<boolean> {
+  const { includeSkill } = await inquirer.prompt([
+    {
+      type: 'confirm',
+      name: 'includeSkill',
+      message: 'Include the Contentful app-building AI skill?',
+      default: true,
+    },
+  ]);
+  return includeSkill;
+}
+
+/**
+ * Resolves whether the app-building skill should be installed.
+ *
+ * - An explicit opt-out (`--skip-skills`, or commander's `--no-skills` which sets
+ *   `skills: false`) always wins and never prompts.
+ * - In interactive mode, the user is prompted (default yes).
+ * - In non-interactive / flagged runs, the skill is installed by default.
+ */
+export async function resolveShouldIncludeSkill(
+  options: CLIOptions,
+  isInteractive: boolean,
+  prompt: () => Promise<boolean> = promptIncludeSkill
+): Promise<boolean> {
+  if (options.skipSkills === true || options.skills === false) {
+    return false;
+  }
+
+  if (isInteractive) {
+    return prompt();
+  }
+
+  return true;
+}

--- a/packages/contentful--create-contentful-app/src/skills.ts
+++ b/packages/contentful--create-contentful-app/src/skills.ts
@@ -10,7 +10,7 @@ export const APP_BUILDING_SKILL = 'contentful-custom-app-from-scratch';
  * The command a user can run manually to install the skill later. Kept in sync
  * with the arguments passed to the default runner below.
  */
-export const MANUAL_INSTALL_COMMAND = `npx skills add ${SKILLS_SOURCE} --skill ${APP_BUILDING_SKILL}`;
+export const MANUAL_INSTALL_COMMAND = `npx -y skills add ${SKILLS_SOURCE} --skill ${APP_BUILDING_SKILL} -y`;
 
 /**
  * Runs the skill installer in the given app folder. Resolves on success and
@@ -60,8 +60,9 @@ export async function installAppBuildingSkill(
     console.log(`${success('Done!')} Added the ${highlight(APP_BUILDING_SKILL)} skill to your app.`);
     return true;
   } catch (e) {
+    const reason = e instanceof Error ? e.message : String(e);
     warn(
-      `Could not install the Contentful app-building AI skill. Your app was created successfully. ` +
+      `Could not install the Contentful app-building AI skill (${reason}). Your app was created successfully. ` +
         `To add it later, run ${choice(MANUAL_INSTALL_COMMAND)} inside your app folder.`
     );
     return false;

--- a/packages/contentful--create-contentful-app/src/types.ts
+++ b/packages/contentful--create-contentful-app/src/types.ts
@@ -8,6 +8,9 @@ export type CLIOptions = Partial<{
   example: string;
   function: string | boolean;
   skipUi: boolean;
+  skipSkills: boolean;
+  // Set to `false` by commander's `--no-skills` flag; opts out of skill install.
+  skills: boolean;
 }>;
 
 export type PackageManager = 'npm' | 'yarn' | 'pnpm';

--- a/packages/contentful--create-contentful-app/test/skills.spec.ts
+++ b/packages/contentful--create-contentful-app/test/skills.spec.ts
@@ -1,0 +1,98 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+  installAppBuildingSkill,
+  resolveShouldIncludeSkill,
+  MANUAL_INSTALL_COMMAND,
+} from '../src/skills';
+import type { CLIOptions } from '../src/types';
+
+describe('skills', () => {
+  describe('installAppBuildingSkill', () => {
+    let consoleLogSpy;
+
+    beforeEach(() => {
+      consoleLogSpy = sinon.spy(console, 'log');
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('returns true and runs the installer in the app folder on success', async () => {
+      const run = sinon.stub().resolves();
+
+      const result = await installAppBuildingSkill('/tmp/my-app', { run });
+
+      expect(result).to.be.true;
+      expect(run.calledOnceWith('/tmp/my-app')).to.be.true;
+    });
+
+    it('returns false and warns with the manual command when the installer fails', async () => {
+      const run = sinon.stub().rejects(new Error('offline'));
+
+      const result = await installAppBuildingSkill('/tmp/my-app', { run });
+
+      expect(result).to.be.false;
+      const logged = consoleLogSpy.getCalls().map((c) => c.args[0]);
+      const warning = logged.find((line) => typeof line === 'string' && line.includes('Warning'));
+      expect(warning, 'a warning should be logged').to.exist;
+      expect(warning).to.include(MANUAL_INSTALL_COMMAND);
+    });
+
+    it('does not throw when the installer rejects', async () => {
+      const run = sinon.stub().rejects(new Error('boom'));
+      // Should resolve (to false), never reject.
+      await expect(installAppBuildingSkill('/tmp/my-app', { run })).to.eventually.equal(false);
+    });
+  });
+
+  describe('resolveShouldIncludeSkill', () => {
+    it('returns false without prompting when --skip-skills is set', async () => {
+      const prompt = sinon.stub().resolves(true);
+      const options: CLIOptions = { skipSkills: true };
+
+      const result = await resolveShouldIncludeSkill(options, true, prompt);
+
+      expect(result).to.be.false;
+      expect(prompt.notCalled).to.be.true;
+    });
+
+    it('returns false without prompting when --no-skills sets skills to false', async () => {
+      const prompt = sinon.stub().resolves(true);
+      const options: CLIOptions = { skills: false };
+
+      const result = await resolveShouldIncludeSkill(options, true, prompt);
+
+      expect(result).to.be.false;
+      expect(prompt.notCalled).to.be.true;
+    });
+
+    it('prompts in interactive mode and honors a yes answer', async () => {
+      const prompt = sinon.stub().resolves(true);
+
+      const result = await resolveShouldIncludeSkill({}, true, prompt);
+
+      expect(result).to.be.true;
+      expect(prompt.calledOnce).to.be.true;
+    });
+
+    it('prompts in interactive mode and honors a no answer', async () => {
+      const prompt = sinon.stub().resolves(false);
+
+      const result = await resolveShouldIncludeSkill({}, true, prompt);
+
+      expect(result).to.be.false;
+      expect(prompt.calledOnce).to.be.true;
+    });
+
+    it('defaults to true without prompting in non-interactive mode', async () => {
+      const prompt = sinon.stub().resolves(false);
+
+      const result = await resolveShouldIncludeSkill({}, false, prompt);
+
+      expect(result).to.be.true;
+      expect(prompt.notCalled).to.be.true;
+    });
+  });
+});

--- a/packages/contentful--create-contentful-app/test/skills.spec.ts
+++ b/packages/contentful--create-contentful-app/test/skills.spec.ts
@@ -38,6 +38,8 @@ describe('skills', () => {
       const warning = logged.find((line) => typeof line === 'string' && line.includes('Warning'));
       expect(warning, 'a warning should be logged').to.exist;
       expect(warning).to.include(MANUAL_INSTALL_COMMAND);
+      // Surfaces the underlying failure reason to help support.
+      expect(warning).to.include('offline');
     });
 
     it('does not throw when the installer rejects', async () => {

--- a/packages/create-contentful-app/README.md
+++ b/packages/create-contentful-app/README.md
@@ -55,6 +55,20 @@ Select between predefined and custom templates:
 
 These flags are mutually exclusive. If no flag is provided, the TypeScript template is used.
 
+### AI App-Building Skill
+
+By default, `create-contentful-app` installs Contentful's official app-building AI skill ([`contentful-custom-app-from-scratch`](https://github.com/contentful/skills)) into your new app. The skill gives AI coding harnesses (Claude Code, OpenAI Codex, Cursor, and others) expert guidance for building Contentful apps. It is pulled live via the [`skills`](https://skills.sh) CLI at scaffold time, so you always get the current version, and the CLI automatically detects your harness.
+
+In interactive mode you are asked whether to include it (default yes). Installation is best-effort: if it fails (e.g. you are offline), your app is still created and a message shows the command to add it later.
+
+- `--skip-skills` (or `--no-skills`): do not install the app-building skill.
+
+To install it manually later, run this inside your app folder:
+
+```bash
+npx skills add contentful/skills --skill contentful-custom-app-from-scratch
+```
+
 ### Help
 
 `--help`
@@ -87,5 +101,7 @@ Options:
                                                 format: URL (HTTPS or SSH) or vendor:user/repo (e.g., github:user/repo)
   -f, --function <function-template-name>       include the specified function template
   --skip-ui                                     use with --function to clone the template without a user interface (UI).
+  --skip-skills                                 skip installing the Contentful app-building AI skill into the new app
+  --no-skills                                   alias for --skip-skills
   -h, --help                                    shows all available CLI options
 ```

--- a/packages/create-contentful-app/README.md
+++ b/packages/create-contentful-app/README.md
@@ -66,7 +66,7 @@ In interactive mode you are asked whether to include it (default yes). Installat
 To install it manually later, run this inside your app folder:
 
 ```bash
-npx skills add contentful/skills --skill contentful-custom-app-from-scratch
+npx -y skills add contentful/skills --skill contentful-custom-app-from-scratch -y
 ```
 
 ### Help


### PR DESCRIPTION
## What

`create-contentful-app` now installs Contentful's official app-building AI skill ([`contentful-custom-app-from-scratch`](https://github.com/contentful/skills)) into scaffolded apps, so developers using agent-driven harnesses get expert guidance out of the box.

The skill is pulled live at scaffold time via the [`skills`](https://skills.sh) CLI (`npx skills add contentful/skills --skill contentful-custom-app-from-scratch`), which:
- **auto-detects the AI harness** — Claude Code, OpenAI Codex, Cursor, Gemini CLI, and others (a real scaffold run reported `Installing to: Antigravity, Claude Code, Codex, Cursor, Gemini CLI`);
- **always pulls the current skill** — nothing is hard-coded or vendored.

## How it behaves

- **Interactive runs**: prompts "Include the Contentful app-building AI skill?" (default **yes**).
- **Flagged/non-interactive runs**: installs by default.
- **Opt out**: `--skip-skills` (or `--no-skills`) skips it with no prompt.
- **Best-effort**: if install fails (offline, npx error, …), a warning prints the manual command and the app is still created successfully (exit 0).

## Changes

- `src/skills.ts` (new) — best-effort installer + prompt/opt-out resolution.
- `src/index.ts` — `--skip-skills` / `--no-skills` options; install step after dependency install.
- `src/types.ts` — `skipSkills` / `skills` on `CLIOptions`.
- `test/skills.spec.ts` (new) — 8 mocha/chai/sinon tests (install success, failure-continues, no-throw, all resolve/skip paths).
- READMEs (both packages) — new "AI App-Building Skill" section + `--help` rows.

## Verification

- `tsc` build: clean · `npm run lint`: 0 errors (new files clean) · `npm test`: **72 passing** (8 new).
- End-to-end: default scaffold installs the skill (`SKILL.md` present in the new app); `--skip-skills` scaffolds with no skill step and no artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)