### PR TITLE
chore(deps): bump adm-zip from 0.5.17 to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4987,12 +4987,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/agent-base": {
@@ -14264,7 +14264,7 @@
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
         "@segment/analytics-node": "^3.0.0",
-        "adm-zip": "0.5.17",
+        "adm-zip": "0.6.0",
         "axios": "^1.15.2",
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",

--- a/packages/contentful--app-scripts/package.json
+++ b/packages/contentful--app-scripts/package.json
@@ -50,7 +50,7 @@
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
     "@segment/analytics-node": "^3.0.0",
-    "adm-zip": "0.5.17",
+    "adm-zip": "0.6.0",
     "axios": "^1.15.2",
     "bottleneck": "2.19.5",
     "chalk": "4.1.2",


### PR DESCRIPTION
chore(deps): bump adm-zip from 0.5.17 to 0.6.0

adm-zip  <0.6.0
Severity: high
adm-zip: Crafted ZIP file triggers 4GB memory allocation - https://github.com/advisories/GHSA-xcpc-8h2w-3j85