### PR TITLE
feat: add experience-toolbar to location prompts [AIS-314]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14269,7 +14269,7 @@
         "bottleneck": "2.19.5",
         "chalk": "4.1.2",
         "commander": "12.1.0",
-        "contentful-management": "^12.8.0",
+        "contentful-management": "^12.9.0",
         "dotenv": "17.4.2",
         "esbuild": "^0.28.0",
         "ignore": "7.0.5",
@@ -14350,9 +14350,9 @@
       }
     },
     "packages/contentful--app-scripts/node_modules/contentful-management": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.8.0.tgz",
-      "integrity": "sha512-lARtEZYn2MYf80hz9nCYiLbJWvg95TTnOWmCZouMZtgNS1273dN27Vaz7weHQ3oSQuk7LeYXaXdGFhFPKlpilw==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.9.0.tgz",
+      "integrity": "sha512-d3vQLs12OJkb4iw/Il0QjGzlNgP3UqxibHLw872bN6ZrOFPCbTI3/gJ00s3okX0gMyIeDvaNbQMhqy7xvmBWfA==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",

--- a/packages/contentful--app-scripts/package.json
+++ b/packages/contentful--app-scripts/package.json
@@ -55,7 +55,7 @@
     "bottleneck": "2.19.5",
     "chalk": "4.1.2",
     "commander": "12.1.0",
-    "contentful-management": "^12.8.0",
+    "contentful-management": "^12.9.0",
     "dotenv": "17.4.2",
     "esbuild": "^0.28.0",
     "ignore": "7.0.5",

--- a/packages/contentful--app-scripts/src/create-type-safe-locations.test.ts
+++ b/packages/contentful--app-scripts/src/create-type-safe-locations.test.ts
@@ -69,6 +69,20 @@ describe('createTypeSafeLocations', () => {
     ]);
   });
 
+  it('should return an array of objects with just location for experience-toolbar', () => {
+    const settings: LocationsSettings = {
+      locations: ['experience-toolbar'],
+    };
+
+    const result = createTypeSafeLocations(settings);
+
+    assert.deepEqual(result, [
+      {
+        location: 'experience-toolbar',
+      },
+    ]);
+  });
+
   it('should return an empty array if locations array is empty', () => {
     const settings: LocationsSettings = {
       locations: [],

--- a/packages/contentful--app-scripts/src/location-prompts.ts
+++ b/packages/contentful--app-scripts/src/location-prompts.ts
@@ -11,6 +11,7 @@ export const selectLocationsPrompt = {
     { name: 'Entry editor', value: 'entry-editor' },
     { name: 'Page', value: 'page' },
     { name: 'Home', value: 'home' },
+    { name: 'Experience and fragment canvas toolbar', value: 'experience-toolbar' },
   ],
 };
 


### PR DESCRIPTION
## Summary
- Adds **Experience and fragment canvas toolbar** (`experience-toolbar`) to the interactive location checkbox shared by `create-app-definition` and `add-locations`.
- Bumps `contentful-management` to `^12.9.0` so App Definition locations type-check with `{ location: 'experience-toolbar' }`.
- Extends `createTypeSafeLocations` unit coverage for the new location.

## Test plan
- [x] `cd packages/contentful--app-scripts && npm test`
- [x] Confirm prompt choices include Experience and fragment canvas toolbar after Home
- [x] Selecting it produces `{ location: 'experience-toolbar' }` via `createTypeSafeLocations`


Made with [Cursor](https://cursor.com) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR adds support for the 'experience-toolbar' App Definition location to the contentful app scripts toolkit, enabling developers to select the Experience and fragment canvas toolbar location when creating or configuring Contentful apps via the interactive CLI prompts.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds 'Experience and fragment canvas toolbar' (experience-toolbar) as a new checkbox option in selectLocationsPrompt, appearing after 'Home' in the location selection menu used by create-app-definition and add-locations commands</li>

<li>Extends unit test coverage for createTypeSafeLocations with a new test case verifying the experience-toolbar location produces the correct { location: 'experience-toolbar' } object in App Definition manifests</li>

<li>The change enables type-safe location definitions for apps targeting the Experience and fragment canvas toolbar surface within Contentful</li>

</ul>
</details>

</div>