### PR TITLE
ci: use Node-bundled npm in Release [AIS-342]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,12 +64,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.22.1'
+          # Major line: Node owns npm. Floating npm@latest breaks when engines diverge.
+          node-version: '22'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Install latest npm
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Release has been failing at `Install latest npm` with `EBADENGINE` ([run](https://github.com/contentful/create-contentful-app/actions/runs/30025763811)): `npm@latest` is now npm 12, which requires Node `^22.22.2+`, while Release was pinned to `22.22.1`.

- Remove the floating `npm install -g npm@latest` step
- Use the npm shipped with Node via `actions/setup-node` (same approach as CI)
- Track Node `22` instead of a pinned patch so engines stay aligned

Same pattern as [ui-extensions-sdk#2629](https://github.com/contentful/ui-extensions-sdk/pull/2629).

## Ticket

https://contentful.atlassian.net/browse/AIS-342

## Why

Floating `npm@latest` against a pinned Node patch is an unstable equilibrium — when npm’s engine range moves, Release breaks even though the app code is fine.

## Risk and Rollout

- **Risk**: Low — CI already installs/builds with Node-bundled npm on the 22.x line
- **Rollout**: Merge → CI on this PR → Release re-runs after the next green CI on `main` (or `workflow_dispatch`)
- **Rollback**: Revert this PR

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, Release gets past Setup Node.js / Install dependencies (no `EBADENGINE`)
- [ ] Confirm Release logs show the Node-bundled npm version (not npm 12 from `npm@latest`)

Made with [Cursor](https://cursor.com) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Fixes the Release workflow's EBADENGINE error by removing the floating npm@latest step and using the npm bundled with Node instead. The change switches from a pinned Node patch version (22.22.1) to a floating major version (22), ensuring npm and Node engine requirements stay aligned.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes the `Install latest npm` step (npm install -g npm@latest) from release.yaml that was causing EBADENGINE failures when npm 12 required a newer Node version than the pinned 22.22.1</li>

<li>Changes node-version from pinned '22.22.1' to floating '22' to allow the setup-node action to use the npm bundled with the Node major line</li>

<li>Adds clarifying comment documenting the rationale for using Node-bundled npm instead of floating npm@latest</li>

</ul>
</details>

</div>