### PR TITLE
ci: pin npm 11.18 for OIDC publish [AIS-342]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,10 +64,15 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          # Major line: Node owns npm. Floating npm@latest breaks when engines diverge.
           node-version: '22'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
+
+      # Unscoped create-contentful-app publishes to npmjs via OIDC trusted publishing
+      # (NPM_CONFIG_PROVENANCE). That needs npm >= 11.5.1; Node 22 ships 10.x.
+      # Pin 11.x — do not use npm@latest (12+ has tighter Node engines).
+      - name: Install npm for trusted publishing
+        run: npm install -g npm@11.18.0
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Follow-up to #3101. Dropping `npm@latest` fixed the `EBADENGINE` install failure, but left Release on Node’s bundled npm **10.9.x**. The unscoped `create-contentful-app` package publishes to npmjs via **OIDC trusted publishing**, which needs **npm ≥ 11.5.1** — so publish failed with `E404` ([run](https://github.com/contentful/create-contentful-app/actions/runs/30030563033)).

- Install pinned `npm@11.18.0` in Release (not `@latest`)
- Keep Node on the `22` major line

## Ticket

https://contentful.atlassian.net/browse/AIS-342

## Why

Scoped `@contentful/*` packages publish to GitHub Packages with a token and were fine. Only the unscoped CLI wrapper (`npx create-contentful-app`) hits npmjs OIDC. Tags/versions for **4.1.0** are already on `main`; this re-run should publish the missing wrapper and skip already-published scoped packages.

## Risk and Rollout

- **Risk**: Low — restores the npm 11.x line that last succeeded (2026-07-02)
- **Rollout**: Merge → CI → Release auto-runs → verify `npm view create-contentful-app version` is `4.1.0`
- **Rollback**: Revert this PR

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, Release gets past publish
- [ ] `npm view create-contentful-app version` → `4.1.0`
- [ ] Wrapper depends on `@contentful/create-contentful-app@4.1.0`

Made with [Cursor](https://cursor.com) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>Pins npm to version 11.18.0 in the Release GitHub Actions workflow to resolve OIDC trusted publishing failures for the unscoped create-contentful-app package. Node 22's bundled npm 10.9.x lacks the npm >= 11.5.1 requirement needed for publishing to npmjs via OIDC, causing an E404 error during release. Scoped @contentful/* packages that publish to GitHub Packages are unaffected by this change.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Adds npm@11.18.0 installation step to enable OIDC trusted publishing for create-contentful-app to npmjs (requires npm >= 11.5.1)</li>

<li>Adds explanatory comments clarifying OIDC requirement for npm version and caution against using npm@latest (12+ has stricter Node engines)</li>

<li>Removes obsolete comment about floating npm@latest breaking when engines diverge</li>

</ul>
</details>

</div>