### PR TITLE
fix: paginate organization list in app-scripts [AIS-350]

### DIFF
--- a/packages/contentful--app-scripts/src/create-app-definition/create-app-definition.ts
+++ b/packages/contentful--app-scripts/src/create-app-definition/create-app-definition.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { PlainClientAPI, createClient } from 'contentful-management';
+import { OrganizationProps, PlainClientAPI, createClient } from 'contentful-management';
 import chalk from 'chalk';
 import { isString, isPlainObject, has } from 'lodash';
 
@@ -12,9 +12,22 @@ import { createTypeSafeLocations } from '../create-type-safe-locations';
 
 async function fetchOrganizations(client: PlainClientAPI) {
   try {
-    const orgs = await client.organization.getAll();
+    const batchedOrganizations: OrganizationProps[] = [];
+    let skip = 0;
+    let totalNumOfOrganizations = 0;
 
-    return orgs.items.map((org) => ({
+    while (skip === 0 || batchedOrganizations.length < totalNumOfOrganizations) {
+      const organizationsResponse = await client.organization.getAll({
+        query: { skip, limit: 100 },
+      });
+
+      totalNumOfOrganizations = organizationsResponse.total;
+      batchedOrganizations.push(...organizationsResponse.items);
+
+      skip += 100;
+    }
+
+    return batchedOrganizations.map((org) => ({
       name: org.name,
       value: org.sys.id,
     }));

--- a/packages/contentful--app-scripts/src/organization-api.test.ts
+++ b/packages/contentful--app-scripts/src/organization-api.test.ts
@@ -17,6 +17,8 @@ describe('organization-api', () => {
     selectFromListMock: SinonStub;
 
   beforeEach(() => {
+    stub(console, 'log');
+
     getAllStub = stub();
     clientMock = {
       organization: { getAll: getAllStub },
@@ -36,6 +38,10 @@ describe('organization-api', () => {
         start: () => ({ stop: stub() }),
       }),
     }));
+  });
+
+  afterEach(() => {
+    (console.log as SinonStub).restore();
   });
 
   it('fetches all organizations across multiple pages', async () => {
@@ -69,12 +75,9 @@ describe('organization-api', () => {
   });
 
   it('throws when unable to fetch organizations', async () => {
-    stub(console, 'log');
     getAllStub.rejects(new Error('network'));
 
     await assert.rejects(() => selectOrganization(clientMock), /Could not fetch your organizations/);
     assert((console.log as SinonStub).calledWith(match(/Could not fetch your organizations/)));
-
-    (console.log as SinonStub).restore();
   });
 });

--- a/packages/contentful--app-scripts/src/organization-api.test.ts
+++ b/packages/contentful--app-scripts/src/organization-api.test.ts
@@ -1,0 +1,80 @@
+import { stub, match, SinonStub } from 'sinon';
+import proxyquire from 'proxyquire';
+import assert from 'assert';
+import { PlainClientAPI } from 'contentful-management';
+
+function makeOrgs(start: number, count: number) {
+  return Array.from({ length: count }, (_, i) => {
+    const n = start + i;
+    return { name: `Org ${n}`, sys: { id: `org-${n}` } };
+  });
+}
+
+describe('organization-api', () => {
+  let selectOrganization: typeof import('./organization-api').selectOrganization,
+    clientMock: PlainClientAPI,
+    getAllStub: SinonStub,
+    selectFromListMock: SinonStub;
+
+  beforeEach(() => {
+    getAllStub = stub();
+    clientMock = {
+      organization: { getAll: getAllStub },
+    } as unknown as PlainClientAPI;
+
+    selectFromListMock = stub().resolves({ name: 'Org 1', value: 'org-1' });
+
+    ({ selectOrganization } = proxyquire('./organization-api', {
+      './utils': {
+        selectFromList: selectFromListMock,
+        throwError: (_err: Error, message: string) => {
+          console.log(message);
+          throw new Error(message);
+        },
+      },
+      ora: () => ({
+        start: () => ({ stop: stub() }),
+      }),
+    }));
+  });
+
+  it('fetches all organizations across multiple pages', async () => {
+    const page1 = makeOrgs(1, 100);
+    const page2 = makeOrgs(101, 5);
+
+    getAllStub.onFirstCall().resolves({ items: page1, total: 105 });
+    getAllStub.onSecondCall().resolves({ items: page2, total: 105 });
+
+    await selectOrganization(clientMock);
+
+    assert.strictEqual(getAllStub.callCount, 2);
+    assert.deepStrictEqual(getAllStub.firstCall.args[0], { query: { skip: 0, limit: 100 } });
+    assert.deepStrictEqual(getAllStub.secondCall.args[0], { query: { skip: 100, limit: 100 } });
+
+    const organizations = selectFromListMock.firstCall.args[0];
+    assert.strictEqual(organizations.length, 105);
+    assert.deepStrictEqual(organizations[0], { name: 'Org 1', value: 'org-1' });
+    assert.deepStrictEqual(organizations[104], { name: 'Org 105', value: 'org-105' });
+  });
+
+  it('fetches a single page when all orgs fit', async () => {
+    const page1 = makeOrgs(1, 3);
+    getAllStub.resolves({ items: page1, total: 3 });
+
+    await selectOrganization(clientMock);
+
+    assert.strictEqual(getAllStub.callCount, 1);
+    assert.deepStrictEqual(getAllStub.firstCall.args[0], { query: { skip: 0, limit: 100 } });
+    assert.strictEqual(selectFromListMock.firstCall.args[0].length, 3);
+  });
+
+  it('throws when unable to fetch organizations', async () => {
+    stub(console, 'log');
+    getAllStub.rejects(new Error('network'));
+
+    await assert.rejects(() => selectOrganization(clientMock), /Could not fetch your organizations/);
+    assert((console.log as SinonStub).calledWith(match(/Could not fetch your organizations/)));
+
+    (console.log as SinonStub).restore();
+  });
+});

--- a/packages/contentful--app-scripts/src/organization-api.ts
+++ b/packages/contentful--app-scripts/src/organization-api.ts
@@ -1,7 +1,7 @@
 import ora from 'ora';
 import { selectFromList, throwError } from './utils';
 import { ORG_ID_ENV_KEY } from './constants';
-import { PlainClientAPI } from 'contentful-management';
+import { OrganizationProps, PlainClientAPI } from 'contentful-management';
 
 export interface Organization {
   name: string;
@@ -10,9 +10,22 @@ export interface Organization {
 
 async function fetchOrganizations(client: PlainClientAPI): Promise<Organization[]> {
   try {
-    const orgs = await client.organization.getAll();
+    const batchedOrganizations: OrganizationProps[] = [];
+    let skip = 0;
+    let totalNumOfOrganizations = 0;
 
-    return orgs.items.map((org) => ({
+    while (skip === 0 || batchedOrganizations.length < totalNumOfOrganizations) {
+      const organizationsResponse = await client.organization.getAll({
+        query: { skip, limit: 100 },
+      });
+
+      totalNumOfOrganizations = organizationsResponse.total;
+      batchedOrganizations.push(...organizationsResponse.items);
+
+      skip += 100;
+    }
+
+    return batchedOrganizations.map((org) => ({
       name: org.name,
       value: org.sys.id,
     }));


### PR DESCRIPTION
[AIS-350](https://contentful.atlassian.net/browse/AIS-350)

## Summary
- Interactive org picker in `@contentful/app-scripts` only returned the first CMA page of organizations (default limit 100)
- Batch `organization.getAll` with `skip` / `limit: 100` in `organization-api.ts` and `create-app-definition.ts`, matching the existing app-definition pagination from #2248

## Test plan
- [x] Unit tests cover multi-page and single-page org fetch (`organization-api.test.ts`)
- [x] Existing `createAppDefinition` tests still pass
- [ ] Manual: with a token that has >100 orgs, run interactive `npm run upload` and confirm the target org appears (or verify via debugger that multiple `getAll` calls fire)
- [x] Confirm `--organization-id` / `CONTENTFUL_ORG_ID` path is unchanged

Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)

[AIS-350]: https://contentful.atlassian.net/browse/AIS-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This PR fixes a bug where the interactive organization picker in @contentful/app-scripts only returned the first page of organizations (default CMA limit of 100). The fix implements batched pagination with skip/limit parameters to fetch all organizations across multiple API pages, applying the same pattern used in existing app-definition pagination from PR #2248.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Implements batched organization fetching with pagination in organization-api.ts, replacing the single uncapped getAll() call with a while loop that uses skip/limit: 100 to retrieve all organizations across multiple pages</li>

<li>Applies identical pagination fix to create-app-definition.ts fetchOrganizations function, ensuring consistent behavior across both organization picker entry points</li>

<li>Adds comprehensive unit tests in organization-api.test.ts covering multi-page fetch (105 orgs across 2 pages), single-page fetch, and error handling scenarios with proper pagination parameter verification</li>

</ul>
</details>

</div>