### PR TITLE
ci: fix always-true OS conditionals in composite actions [AIS-351]

### DIFF
--- a/.github/actions/lint-and-test/action.yml
+++ b/.github/actions/lint-and-test/action.yml
@@ -12,19 +12,19 @@ runs:
   using: 'composite'
   steps:
     - name: Lint (Linux only)
-      if: ${{ inputs.os }} == 'ubuntu-latest'
+      if: inputs.os == 'ubuntu-latest'
       shell: bash
       run: npm run lint
 
     - name: Run tests (Linux only)
-      if: ${{ inputs.os }} == 'ubuntu-latest'
+      if: inputs.os == 'ubuntu-latest'
       shell: bash
       run: npm test
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
 
     - name: Run tests (Windows)
-      if: ${{ inputs.os }} == 'windows-latest'
+      if: inputs.os == 'windows-latest'
       shell: pwsh
       run: npm test
       env:

--- a/.github/actions/test-app/action.yml
+++ b/.github/actions/test-app/action.yml
@@ -8,7 +8,7 @@ runs:
   using: 'composite'
   steps:
     - name: Test built wrapper app (Unix)
-      if: ${{ inputs.os }} == 'ubuntu-latest'
+      if: inputs.os == 'ubuntu-latest'
       shell: bash
       run: |
         FORMER_CWD="$(pwd)"
@@ -20,7 +20,7 @@ runs:
         npm t
 
     - name: Test built wrapper app (Windows)  
-      if: ${{ inputs.os }} == 'windows-latest'
+      if: inputs.os == 'windows-latest'
       shell: pwsh
       run: |
         $FORMER_CWD = (Get-Location).Path

--- a/.github/actions/test-functions/action.yml
+++ b/.github/actions/test-functions/action.yml
@@ -8,7 +8,7 @@ runs:
   using: 'composite'
   steps:
     - name: Test built functions (Unix)
-      if: ${{ inputs.os }} == 'ubuntu-latest'
+      if: inputs.os == 'ubuntu-latest'
       shell: bash
       run: |
         FORMER_CWD="$(pwd)"
@@ -20,7 +20,7 @@ runs:
         node "${FORMER_CWD}/packages/contentful--app-scripts/lib/bin.js" build-functions --ci
 
     - name: Test built functions (Windows)
-      if: ${{ inputs.os }} == 'windows-latest'
+      if: inputs.os == 'windows-latest'
       shell: pwsh
       run: |
         $FORMER_CWD = (Get-Location).Path


### PR DESCRIPTION
## Summary
Fix broken `if` conditions in CI composite actions so only the OS-appropriate step runs.

`${{ inputs.os }} == 'ubuntu-latest'` was always truthy, so both bash and pwsh scaffold/test steps executed on every matrix job (4 fresh `npm install`s instead of 2). That roughly doubled work, and on Windows each install is ~3–4 minutes.

Aligned `test-app`, `test-functions`, and `lint-and-test` with the working pattern already used in `install-and-build`.

## Ticket
https://contentful.atlassian.net/browse/AIS-351

## Why
Windows CI was ~16m vs ~2.5m on Ubuntu for the same matrix; most of the avoidable cost was duplicate scaffold installs from always-true conditionals.

## Risk and Rollout
Low — CI-only YAML change. Verify in this PR that each job runs a single OS step for test-app/test-functions, and Windows wall time drops roughly in half.
