### PR TITLE
chore(renovate): migrate GH npm token off encrypted config [AIS-390]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,9 +11,7 @@
     {
       "matchHost": "npm.pkg.github.com",
       "hostType": "npm",
-      "encrypted": {
-        "token": "{{secrets.NPM_REGISTRY_REGISTRY_GH_ORG_TOKEN}}"
-      }
+      "token": "{{ secrets.NPM_REGISTRY_REGISTRY_GH_ORG_TOKEN }}"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
[AIS-390](https://contentful.atlassian.net/browse/AIS-390)

Closes #3106

## Summary
- Remove unsupported `encrypted` wrapper from Renovate `hostRules` for `npm.pkg.github.com`
- Reference the existing Mend org secret directly via `{{ secrets.NPM_REGISTRY_REGISTRY_GH_ORG_TOKEN }}` (same pattern as `app-framework-internal`)

## Test plan
- [ ] Confirm Renovate config validation succeeds after merge (issue #3106 should close / stop erroring)
- [ ] Confirm Renovate resumes opening dependency PRs
- [ ] Spot-check that private GitHub Packages lookups still authenticate

Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)

[AIS-390]: https://contentful.atlassian.net/browse/AIS-390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ