### PR TITLE
chore(renovate): drop unused GH Packages hostRules [AIS-390]

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,16 +4,6 @@
   "npm": {
     "enabled": true
   },
-  "registryAliases": {
-    "npm-github": "https://npm.pkg.github.com"
-  },
-  "hostRules": [
-    {
-      "matchHost": "npm.pkg.github.com",
-      "hostType": "npm",
-      "token": "{{ secrets.NPM_REGISTRY_REGISTRY_GH_ORG_TOKEN }}"
-    }
-  ],
   "packageRules": [
     {
       "matchPackageNames": ["@types/node"],


### PR DESCRIPTION
[AIS-390](https://contentful.atlassian.net/browse/AIS-390)

Closes #3108

## Summary
- Root cause of the follow-up Renovate failure: `{{ secrets.NPM_REGISTRY_REGISTRY_GH_ORG_TOKEN }}` looks up a **Mend** secret, not the GitHub Actions org secret of the same name — and that Mend secret does not exist
- This repo does not need GitHub Packages auth for Renovate: `.npmrc` sends `@contentful` to npmjs, and `package-lock.json` has zero `npm.pkg.github.com` resolutions
- Remove vestigial Dependabot-era `hostRules` + `registryAliases` so Renovate can resume

## Test plan
- [ ] Renovate config error issue #3108 closes / stops erroring after merge
- [ ] Renovate resumes opening dependency PRs against public npm packages
- [ ] No private GitHub Packages lookups required for this repo's lockfile

Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)

[AIS-390]: https://contentful.atlassian.net/browse/AIS-390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ