### PR TITLE
chore: remove obsolete dependabot Vault policy [MEC-3526]

### DIFF
--- a/.contentful/vault-secrets.yaml
+++ b/.contentful/vault-secrets.yaml
@@ -2,7 +2,6 @@ version: 1
 services:
   github-action:
     policies:
-      - dependabot
       - semantic-release
   circleci:
     policies:


### PR DESCRIPTION
Removes the `dependabot` entry from `.contentful/vault-secrets.yaml`.

This policy was used when Dependabot needed Vault-sourced secrets for GitHub Actions. The repo has since been migrated to Renovate, which runs as an org-level GitHub App and does not require a repo-local Vault secret policy. The entry is now dead weight.

No functional change — this is a cleanup of a leftover artifact from the Dependabot-to-Renovate migration.

## Migration Confidence: 🟢 High

### Summary

Removed the `- dependabot` entry from the `policies` list under `github-action` in `.contentful/vault-secrets.yaml`. The remaining `semantic-release` policy and all other sections (`circleci`, etc.) are untouched, and no empty YAML structures were left behind. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This cleanup removes a leftover Dependabot Vault policy from the repository after the migration to Renovate, which operates as an organization-level GitHub App and does not require the repository-local policy. The change is limited to Vault policy configuration and does not alter application behavior or dependencies.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Removes the obsolete `dependabot` Vault policy from the `github-action` service in `vault-secrets.yaml`, eliminating an unused repository-local secret access configuration.</li>

<li>Preserves the `semantic-release` policy and all `circleci` policies in `vault-secrets.yaml`, leaving the YAML service structure valid and otherwise unchanged.</li>

</ul>
</details>

</div>