### PR TITLE
docs: seed decision records with nx release ADR [EXT-7521]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,14 @@ packages/
 - **`contentful-app-manifest.json` is never removed after cloning** — it's in `IGNORED_CLONED_FILES`. When using `--action` or `--function` flags, the manifest is merged (not replaced) into the scaffolded app root.
 - **`--action` and `--function` flags run a merge step** — both `build-actions.js` / `build-functions.js` are moved to root and `build:actions` / `build:functions` scripts are injected into the generated `package.json`.
 - **`useSDK()` and `useAutoResizer()`** from `@contentful/react-apps-toolkit` are the canonical React hooks for all 56 apps in the `apps` monorepo. Changes to hook signatures are breaking.
-- **Lerna 6 + Nx** — each package versions independently. Use `lerna run <script>` for cross-package operations.
+- **Nx** — each package versions independently. Use `nx run-many -t <target>` for cross-package
+  operations. Lerna was removed; see
+  [ADR 2026-01-20](./docs/ADRs/2026-01-20-adopt-nx-release-replace-lerna.md).
 
 ## Never / Always
 
 - **Never** rename template folders in the `apps` repo without updating `src/constants.ts` here.
-- **Never** manually bump package versions — releases are automated via semantic-release on `master`.
+- **Never** manually bump package versions — `nx release` versions packages from conventional
+  commits when CI passes on `main`.
 - **Always** test the CLI end-to-end after changes — CI scaffolds a real app and runs its full build + test cycle.
 - **Always** check `@contentful/react-apps-toolkit` for breaking changes before bumping — all apps in the monorepo depend on it.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,21 +68,30 @@ React hooks all apps should use:
 
 ## Monorepo Setup
 
-- **Lerna 6 + Nx** — Nx caches build outputs; Lerna handles versioning and publishing
-- **Independent versioning** — each package has its own semver
-- **Node ≥ 18** — CI tests on multiple Node LTS versions (see `.circleci/config.yml`)
-- **CircleCI** — lint-and-test → test-built-app (real scaffold + build + test) → release
+- **Nx** — owns build caching, task running (`nx run-many`), versioning, and publishing. Lerna
+  was removed in favour of Nx Release; see
+  [ADR 2026-01-20](./docs/ADRs/2026-01-20-adopt-nx-release-replace-lerna.md).
+- **npm workspaces** — `workspaces: ["packages/*"]` handles dependency linking
+- **Independent versioning** — each package has its own semver, driven by conventional commits
+- **Node ≥ 20** — `engines.node` is `>=20`; `.nvmrc` pins `v22`
+- **GitHub Actions** — a CI workflow gates every push and PR; a separate release workflow runs
+  after CI succeeds on `main` or `canary`
 
 ## CI / Release
 
 ```
-Every branch:
-  lint-and-test (Node 18 + 20)
-  test-built-app (scaffold a real app → npm run build + test)
-  test-built-app-actions-functions (scaffold with --action --function flags)
+CI (.github/workflows/ci.yaml) — every push and PR to main or canary:
+  matrix: Node 20.20 / 22.23 / 24.18  ×  ubuntu-latest / windows-latest
+    install-and-build
+    lint-and-test
+    test-app       (scaffold a real app → build + test)
+    test-functions (scaffold with app functions → build)
+  ci-status        (single aggregate status check over the matrix)
 
-master branch (after all tests pass):
-  lerna version --conventional-commits  →  lerna publish from-git
+Release (.github/workflows/release.yaml) — after CI succeeds on main or canary:
+  nx release --skip-publish   (version, changelog, tag)
+  git push --follow-tags
+  nx release publish          (npmjs, OIDC trusted publishing with provenance)
 ```
 
 Canary releases publish from the `canary` branch with `X.Y.Z-alpha.N` format under the `canary` dist-tag.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 | Tool | Version |
 |------|---------|
-| Node.js | ≥ 18 (`.nvmrc`: `lts/*`) |
+| Node.js | ≥ 20 (`.nvmrc`: `v22`) |
 | npm | ≥ 8 |
 
 ## Setup
@@ -18,23 +18,23 @@ npm ci
 ## Running Tests
 
 ```bash
-npm test   # lerna run test — runs Mocha tests across all packages
+npm test   # nx run-many -t test — runs Mocha tests across all packages
 ```
 
 Tests use **Mocha + Chai + Sinon**. Test files are in `packages/<pkg>/test/`.
 
-The CI suite also runs integration tests that scaffold a real app and run its full build + test cycle — these run in CircleCI only.
+The CI suite also runs integration tests that scaffold a real app and run its full build + test cycle — these run in GitHub Actions only, across a Node and OS matrix.
 
 ## Building
 
 ```bash
-npm run build   # lerna run build
+npm run build   # nx run-many -t build
 ```
 
 ## Linting
 
 ```bash
-npm run lint   # lerna run lint
+npm run lint   # nx run-many -t lint
 ```
 
 Prettier runs automatically on staged files via `lint-staged` (Husky pre-commit hook). Don't skip it.
@@ -61,15 +61,18 @@ create-contentful-app my-test-app
 
 ## Releasing
 
-Releases are automated via semantic-release on the `master` branch. Do not manually bump versions.
+Releases are automated via `nx release` on the `main` branch, driven by conventional commits.
+Do not manually bump versions. See
+[ADR 2026-01-20](./docs/ADRs/2026-01-20-adopt-nx-release-replace-lerna.md) for why Nx Release
+replaced Lerna.
 
 **Canary**: merge to the `canary` branch → publishes `X.Y.Z-alpha.N` under the `canary` dist-tag.
 
 ## Branch Strategy
 
-- **`master`** — production; triggers release on merge
+- **`main`** — production; triggers release on merge
 - **`canary`** — prerelease; publishes canary versions
-- **Feature branches** — PR against `master`
+- **Feature branches** — PR against `main`
 
 ## Troubleshooting
 

--- a/docs/ADRs/2026-01-20-adopt-nx-release-replace-lerna.md
+++ b/docs/ADRs/2026-01-20-adopt-nx-release-replace-lerna.md
@@ -1,0 +1,127 @@
+# Adopt Nx Release for versioning and publishing, replacing Lerna
+
+## Status
+
+Accepted
+
+## Context
+
+This monorepo holds four packages under `packages/`, all of which publish to npm: the three
+scoped packages `@contentful/create-contentful-app`, `@contentful/app-scripts`, and
+`@contentful/react-apps-toolkit`, plus the unscoped `create-contentful-app` wrapper that
+`npx create-contentful-app` resolves through. Each package versions independently.
+
+Before this decision the toolchain used **both** Lerna and Nx, with responsibilities split
+between them:
+
+| Concern | Tool |
+|---------|------|
+| Dependency linking | `lerna bootstrap` |
+| Cross-package task running | `lerna run <script>` |
+| Versioning + changelogs | `lerna version --conventional-commits` |
+| Publishing | `lerna publish from-git` |
+| Build caching | Nx |
+
+Both were declared in the root `package.json` — Lerna pinned at `6.6.2`, Nx at `22.3.3`. Nx
+was therefore already a hard dependency of the build, but was doing only a fraction of the
+work it was capable of.
+
+Two concrete problems motivated consolidating:
+
+1. **Release auth friction.** The release workflow rewrote `.npmrc` at runtime, which
+   interfered with Lerna's own registry authentication. `539c226d` ("chore: remove `.npmrc`
+   editing as it interferes with lerna", #2876) removed that step a week before the
+   migration, moving auth into per-package configuration instead.
+2. **Registry migration.** The root `package.json` carried
+   `publishConfig.registry: https://npm.pkg.github.com/`, pinning publishes to GitHub
+   Packages. Moving the published packages to npmjs with OIDC trusted publishing and
+   provenance attestation required control over the publish invocation that the Lerna
+   configuration did not cleanly give.
+
+The alternative to consolidating on Nx was to keep the split and upgrade Lerna. That was
+rejected: it would have meant maintaining two overlapping tools, and `lerna bootstrap` — the
+linking mechanism this repo depended on — had already been superseded by native package
+manager workspaces.
+
+## Decision
+
+Drop Lerna entirely and move versioning, publishing, and task running onto Nx, with npm
+workspaces handling dependency linking.
+
+Implemented in `96d92d99` ("chore: switch to nx", #2883, whose commit body reads
+"chore: remove lerna") and completed by `1d4c1e16` ("chore: enable publishing", #2886).
+
+What changed:
+
+| Concern | Before | After |
+|---------|--------|-------|
+| Dependency linking | `lerna bootstrap` | npm `workspaces: ["packages/*"]` |
+| Task running | `lerna run <script>` | `nx run-many -t <target>` |
+| Versioning | `lerna version --conventional-commits` | `nx release --skip-publish` |
+| Publishing | `lerna publish from-git` | `nx release publish` |
+| Registry | GitHub Packages via `publishConfig` | npmjs via OIDC trusted publishing |
+| Per-package config | `package.json` only | `project.json` per package |
+
+Release configuration moved into `nx.json` under a `release` key: `projectsRelationship:
+"independent"`, `version.conventionalCommits: true`, and `changelog.projectChangelogs: true`
+preserve the independent-versioning and conventional-commit behaviour the repo already
+relied on.
+
+The release workflow also split what Lerna did in one step into three discrete ones —
+prepare (version, changelog, tag locally), push tags, then publish. Failures are now
+attributable to a specific phase rather than to a single opaque command.
+
+## Consequences
+
+### What this enables
+
+- One tool owns the graph. Build caching, task orchestration, versioning, and publishing all
+  read the same project graph, so a package's dependents are computed once rather than
+  inferred separately by two tools.
+- Publishing to npmjs with provenance. `NPM_CONFIG_PROVENANCE` and OIDC trusted publishing
+  give consumers a verifiable link from a published tarball back to the workflow run that
+  built it.
+- Per-phase release failures. A version failure no longer looks identical to a publish
+  failure.
+
+### Trade-offs accepted
+
+- **npm version floor.** OIDC trusted publishing for the unscoped package needs
+  npm >= 11.5.1, but Node 22 ships npm 10.x. The release workflow pins `npm@11.18.0`
+  explicitly — deliberately not `npm@latest`, since npm 12+ tightens Node engine
+  requirements. This pin needs revisiting whenever the workflow's Node version moves.
+- **Nx-specific release semantics.** Release behaviour is now governed by `nx.json` plus the
+  `@nx/js` plugin's defaults rather than by Lerna flags. Those defaults are not always the
+  safe choice for this repo — see below.
+- **Node floor raised.** `engines.node` moved from `>=18` to `>=20`.
+
+### Problems this decision surfaced
+
+Two post-adoption corrections are worth recording, because both trace directly to Nx release
+semantics rather than to any change in this repo's own code:
+
+- **Lockfile-wide version propagation.** `@nx/js` defaults
+  `projectsAffectedByDependencyUpdates` to `"all"`, which treats any change to the root
+  `package-lock.json` as affecting every project in the workspace. Under independent,
+  conventional-commit versioning, a single lockfile-touching commit was therefore attributed
+  to all packages — so a breaking change in one package could major-bump unrelated,
+  unmodified packages. `963d050c` (#3091) set it to `"auto"`, scoping dependency-update
+  detection to packages whose own manifest or source actually changed.
+- **Unpublishable version reference.** A release on 2026-05-13 bumped the unscoped
+  `create-contentful-app` wrapper to depend on `@contentful/create-contentful-app@3.0.0`,
+  which was never published to npm. Three of the four affected packages were rolled back by
+  dist-tag retag; the wrapper was missed. Because `npx create-contentful-app` resolves
+  through that wrapper, every consumer failed with `ETARGET` until `5a7c046a` (#3085) pinned
+  it back to a published version.
+
+The general lesson: under independent versioning, verify that cross-package dependency
+ranges reference versions that actually exist on the registry before publishing.
+
+### Follow-up work
+
+- `lerna.json` is still committed at the repository root despite Lerna being removed from
+  `package.json`. It is dead configuration and should be deleted.
+- `.github/workflows/release.yaml` retains a "Print lerna debug log" step and a run-summary
+  string referring to Lerna, neither of which can fire any more.
+- `.eslintrc.js` carries a comment stating that devDependencies are "hoisted by lerna";
+  hoisting is now npm workspaces' behaviour.

--- a/docs/ADRs/README.md
+++ b/docs/ADRs/README.md
@@ -1,0 +1,24 @@
+# Architecture Decision Records
+
+Each ADR records a single architectural decision, the context that forced it, and the
+consequences the repo now lives with. They are historical records — an accepted ADR is not
+edited to reflect later changes. When a decision is reversed, add a new ADR and mark the old
+one `Superseded by`.
+
+| Date | Status | Title |
+|---|---|---|
+| [2026-01-20](./2026-01-20-adopt-nx-release-replace-lerna.md) | Accepted | Adopt Nx Release for versioning and publishing, replacing Lerna |
+
+## Conventions
+
+- **Filename** — `YYYY-MM-DD-short-title.md`. The date is the date of the decision, taken
+  from the commit, PR, or discussion that made it — not the date the ADR was written. The
+  filename is the canonical identifier; there is no separate sequential numbering.
+- **Sections** — `Status`, `Context`, `Decision`, `Consequences`.
+- **Status** — one of `Accepted`, `Deprecated`, or
+  `Superseded by [YYYY-MM-DD-title](./YYYY-MM-DD-title.md)`.
+- **One decision per record.** Corrections and follow-ups that flow from a decision belong in
+  that decision's `Consequences`, not in new ADRs.
+- **Cite evidence.** Reference commits and pull requests in this repository so a reader can
+  verify the reasoning. Verify commit hashes against `git log` before writing them — this
+  repository is public, so cite only publicly visible sources.


### PR DESCRIPTION
[EXT-7521](https://contentful.atlassian.net/browse/EXT-7521)

## Summary
- Adds `docs/ADRs/` with its first decision record: the January 2026 migration from Lerna to Nx Release for versioning and publishing (`96d92d99`, #2883). This satisfies the `decision-records-present` readiness control, which found no `.md` under `docs/ADRs/`, `docs/adr/`, `docs/decision-records/`, or `docs/decisions/`.
- The ADR records the two-tool split that preceded the migration, the two motivations visible in history (the `.npmrc`/auth friction removed in `539c226d` #2876, and the GitHub Packages → npmjs move that enabled OIDC trusted publishing), and the trade-offs realized since — the `@nx/js` `projectsAffectedByDependencyUpdates` default that major-bumped unrelated packages (`963d050c`, #3091) and the unpublished-version reference that broke `npx create-contentful-app` with `ETARGET` (`5a7c046a`, #3085).
- Corrects the golden context files added in #3073, which still describe the pre-migration repo and would have directly contradicted the new ADR. Every edited line was verifiably wrong against `main`, not merely dated.

### Why the doc corrections are in this PR

Shipping an ADR that says "`nx release` on `main`" while `AGENTS.md` tells agents to "use `lerna run`" and "semantic-release on `master`" would leave the repo contradicting itself on exactly the subject of the ADR. The corrections are surgical — no restructuring, no rewording of accurate content:

| File | Was | Now |
|---|---|---|
| `AGENTS.md` | `lerna run <script>`; semantic-release on `master` | `nx run-many -t <target>`; `nx release` on `main` |
| `ARCHITECTURE.md` | "Lerna 6 + Nx"; CircleCI; Node ≥ 18 | Nx + npm workspaces; GitHub Actions; Node ≥ 20 |
| `ARCHITECTURE.md` | `lerna version` → `lerna publish from-git` diagram | current three-phase `nx release` flow + real CI matrix |
| `CONTRIBUTING.md` | `lerna run test`/`build`/`lint` | `nx run-many -t test`/`build`/`lint` |
| `CONTRIBUTING.md` | branch strategy on `master` | `main` — `master` no longer exists on the remote |

`docs/ADRs/README.md` carries an index plus the filename and sourcing conventions for future records: date-from-source filenames (no sequential numbering), one decision per record, and cite only publicly visible sources since this repo is public. Every commit hash in the ADR was verified against `git log` rather than transcribed.

### Deliberately out of scope

Three stale items were found but left alone to keep this reviewable — worth separate tickets:
- `lerna.json` is still committed at the root despite Lerna being gone from `package.json`; `release.yaml` retains a "Print lerna debug log" step and a run-summary string about Lerna; `.eslintrc.js` has a "hoisted by lerna" comment. All three are noted in the ADR's Follow-up work section.
- `ARCHITECTURE.md` documents `degit` for template cloning and lists it under Key Dependencies, but neither `degit` nor `tiged` is a dependency of the CLI package any more. Unrelated to this migration.
- `CONTRIBUTING.md` still lists `npm ≥ 8`, which is below what Node ≥ 20 ships.

## Test plan
- [ ] Files render correctly on GitHub, including the tables
- [ ] The three relative links to `./docs/ADRs/2026-01-20-adopt-nx-release-replace-lerna.md` resolve from the rendered root docs
- [ ] Spot-check the ADR's commit hashes and PR references against `git log`
- [ ] Confirm no release is triggered — `docs:` only, and `nx.json` excludes `docs/**` from production inputs
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)

[EXT-7521]: https://contentful.atlassian.net/browse/EXT-7521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ