### PR TITLE
fix: validate manifests with shared rules from node-apps-toolkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1997,6 +1997,47 @@
       "resolved": "packages/contentful--create-contentful-app",
       "link": true
     },
+    "node_modules/@contentful/node-apps-toolkit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@contentful/node-apps-toolkit/-/node-apps-toolkit-4.1.0.tgz",
+      "integrity": "sha512-8tGZQUthpJryImVWe4ArlT/iwv4AM303waYoXzNdIx8LjJY+zpmG5XDvZgQ9Yo9Q07N+H99aLZHzkHdG2tC/gA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.5",
+        "contentful-management": "^12.0.0",
+        "debug": "^4.2.0",
+        "got": "^11.7.0",
+        "jsonwebtoken": "^9.0.0",
+        "lru-cache": "^10.4.3",
+        "runtypes": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@contentful/node-apps-toolkit/node_modules/contentful-management": {
+      "version": "12.17.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.17.0.tgz",
+      "integrity": "sha512-ddp/0iXmw5X/lo3kWmFMIc2A4koWN5eF8xnAN6qAKIaaVFxfOyWgOe1mTetbpkMC5R/+XLVFC44Z2kuTWDmF3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/rich-text-types": "^16.6.1",
+        "axios": "^1.15.0",
+        "contentful-sdk-core": "^9.4.4",
+        "fast-copy": "^3.0.0",
+        "globals": "^15.15.0",
+        "process": "^0.11.10"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@contentful/node-apps-toolkit/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
     "node_modules/@contentful/react-apps-toolkit": {
       "resolved": "packages/contentful--react-apps-toolkit",
       "link": true
@@ -3787,6 +3828,18 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -3826,6 +3879,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -4056,6 +4121,18 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -4098,6 +4175,15 @@
         "chalk": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4132,6 +4218,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "license": "MIT"
     },
     "node_modules/@types/inquirer": {
       "version": "8.2.13",
@@ -4239,6 +4331,15 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/lodash": {
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
@@ -4253,11 +4354,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
       "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -4320,6 +4426,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^17.0.0"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/rimraf": {
@@ -5601,6 +5716,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -5616,6 +5737,48 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5963,6 +6126,18 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -6255,6 +6430,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
@@ -6375,6 +6577,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/define-data-property": {
@@ -6593,6 +6804,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ejs": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-5.0.1.tgz",
@@ -6636,7 +6856,6 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -7758,6 +7977,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -7895,6 +8139,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http-proxy-agent": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
@@ -7908,6 +8158,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -10280,8 +10543,7 @@
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -10325,11 +10587,53 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -10561,6 +10865,42 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -10573,6 +10913,12 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -10795,6 +11141,15 @@
         "get-func-name": "^2.0.1"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
@@ -10962,6 +11317,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -11182,6 +11546,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm-run-path": {
@@ -11653,7 +12029,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -11727,6 +12102,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/p-limit": {
@@ -12121,6 +12505,16 @@
         "url": "https://github.com/sponsors/lupomontero"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -12189,6 +12583,18 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -12408,6 +12814,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
+    },
     "node_modules/resolve-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
@@ -12447,6 +12859,18 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -12585,6 +13009,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/runtypes": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/runtypes/-/runtypes-5.1.0.tgz",
+      "integrity": "sha512-OMHkz6dxysXj4E8Fj/HCGjtdJUhapQUN7puvqzuzvjaX28pd52PZmEMqQlkIzCfKdhXdM0ghx8PpvELprEnOLQ==",
+      "license": "MIT"
+    },
     "node_modules/rxjs": {
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -12664,7 +13094,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -13674,7 +14103,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -14062,8 +14490,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
       "version": "5.0.1",
@@ -14276,6 +14703,7 @@
       "version": "4.1.8",
       "license": "MIT",
       "dependencies": {
+        "@contentful/node-apps-toolkit": "^4.1.0",
         "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
         "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
         "@segment/analytics-node": "^3.1.0",

--- a/packages/contentful--app-scripts/package.json
+++ b/packages/contentful--app-scripts/package.json
@@ -47,6 +47,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@contentful/node-apps-toolkit": "^4.1.0",
     "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
     "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
     "@segment/analytics-node": "^3.1.0",

--- a/packages/contentful--app-scripts/src/build-functions/__tests__/build-functions.test.ts
+++ b/packages/contentful--app-scripts/src/build-functions/__tests__/build-functions.test.ts
@@ -102,6 +102,7 @@ describe('validateFunctions', () => {
     assert.throws(() => validateFunctions(manifest));
   });
 
+
   it('should throw an error if a function is missing an accepts', () => {
     const manifest = { ...validManifest };
     manifest.functions = manifest.functions.map((f) => deleteProp(f, 'accepts'));
@@ -123,7 +124,77 @@ describe('validateFunctions', () => {
           entryFile: 'index.ts',
           description: 'My function',
           accepts: ['appaction.call'],
+          path: 'path/to/file.js',
+        },
+      ],
+    };
+    assert.doesNotThrow(() => validateFunctions(manifest));
+  });
+
+  it('should throw an error if a function id exceeds 64 characters', () => {
+    // Regression: this manifest-build-time check only ever validated the
+    // character set (alphanumeric), never a length bound, so an id this
+    // long would pass here and only fail once uploaded to the backend.
+    const manifest = {
+      functions: [
+        {
+          id: 'a'.repeat(65),
+          name: 'myFunc',
+          entryFile: 'index.ts',
+          description: 'My function',
+          accepts: ['appaction.call'],
+          path: 'path/to/file.js',
+        },
+      ],
+    };
+    assert.throws(() => validateFunctions(manifest));
+  });
+
+  it('should not throw an error for a function id at the maximum length of 64 characters', () => {
+    const manifest = {
+      functions: [
+        {
+          id: 'a'.repeat(64),
+          name: 'myFunc',
+          entryFile: 'index.ts',
+          description: 'My function',
+          accepts: ['appaction.call'],
+          path: 'path/to/file.js',
+        },
+      ],
+    };
+    assert.doesNotThrow(() => validateFunctions(manifest));
+  });
+
+  it('should throw an error if a function path does not end in .js or .mjs', () => {
+    // Regression: this manifest-build-time check never validated the shape
+    // of "path" at all, so a path with the wrong (or no) extension would
+    // pass here and only fail once uploaded to the backend.
+    const manifest = {
+      functions: [
+        {
+          id: 'example',
+          name: 'myFunc',
+          entryFile: 'index.ts',
+          description: 'My function',
+          accepts: ['appaction.call'],
           path: 'path/to/file.ts',
+        },
+      ],
+    };
+    assert.throws(() => validateFunctions(manifest));
+  });
+
+  it('should not throw an error for a function path ending in .mjs', () => {
+    const manifest = {
+      functions: [
+        {
+          id: 'example',
+          name: 'myFunc',
+          entryFile: 'index.ts',
+          description: 'My function',
+          accepts: ['appaction.call'],
+          path: 'path/to/file.mjs',
         },
       ],
     };

--- a/packages/contentful--app-scripts/src/build-functions/build-functions.ts
+++ b/packages/contentful--app-scripts/src/build-functions/build-functions.ts
@@ -11,7 +11,8 @@ import {
   isValidHostedCodePath,
   MIN_FUNCTION_ID_LENGTH,
   MAX_FUNCTION_ID_LENGTH,
-} from '@contentful/node-apps-toolkit';
+  // eslint-disable-next-line node/no-missing-import
+} from '@contentful/node-apps-toolkit/validation';
 
 type ContentfulFunctionToBuild = Omit<ContentfulFunction, 'entryFile'> & { entryFile: string };
 

--- a/packages/contentful--app-scripts/src/build-functions/build-functions.ts
+++ b/packages/contentful--app-scripts/src/build-functions/build-functions.ts
@@ -5,7 +5,13 @@ import { NodeModulesPolyfillPlugin } from '@esbuild-plugins/node-modules-polyfil
 import { NodeGlobalsPolyfillPlugin } from '@esbuild-plugins/node-globals-polyfill';
 import { type BuildFunctionsOptions, type ContentfulFunction } from '../types';
 import { z } from 'zod';
-import { ID_REGEX, resolveManifestFile } from '../utils';
+import { resolveManifestFile } from '../utils';
+import {
+  isValidFunctionId,
+  isValidHostedCodePath,
+  MIN_FUNCTION_ID_LENGTH,
+  MAX_FUNCTION_ID_LENGTH,
+} from '@contentful/node-apps-toolkit';
 
 type ContentfulFunctionToBuild = Omit<ContentfulFunction, 'entryFile'> & { entryFile: string };
 
@@ -14,14 +20,17 @@ const functionManifestSchema = z
     functions: z.array(
       z
         .object({
-          id: z.string().regex(ID_REGEX, 'Invalid "id" (must only contain alphanumeric characters)'),
+          id: z
+            .string()
+            .refine(
+              isValidFunctionId,
+              `Invalid "id" (must be ${MIN_FUNCTION_ID_LENGTH}-${MAX_FUNCTION_ID_LENGTH} alphanumeric characters)`
+            ),
           name: z.string(),
           description: z.string(),
-          path: z.string(),
+          path: z.string().refine(isValidHostedCodePath, 'Invalid "path" (must end in .js or .mjs)'),
           entryFile: z.string(),
           accepts: z.array(z.string()),
-        }, {
-
         })
         .required()
     ),

--- a/packages/contentful--app-scripts/src/upsert-actions/validation.test.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/validation.test.ts
@@ -138,6 +138,123 @@ describe('validateActionsManifest', () => {
 		}
 	});
 
+	it('throws if an action id exceeds 64 characters', async () => {
+		const manifest = {
+			actions: [{
+				id: 'a'.repeat(65),
+				type: 'endpoint',
+				name: 'Test Action',
+				category: 'Entries.v1.0',
+				url: 'https://test.com',
+			}]
+		};
+
+		try {
+			await validateActionsManifest(manifest);
+			expect.fail('expected validateActionsManifest to throw');
+		} catch (error) {
+			expect(error).to.be.instanceOf(Error);
+			expect(error.message).to.include('Invalid App Action manifest');
+		}
+	});
+
+	it('accepts a parameter with no "required" field', async () => {
+		// Regression: the previous zod schema marked "required" as
+		// non-optional, even though contentful-management's own type (and
+		// the backend's actual schema) treats it as optional.
+		const manifest = {
+			actions: [{
+				type: 'function-invocation',
+				functionId: 'test-function',
+				name: 'Test Action',
+				category: 'Custom',
+				parameters: [{
+					id: 'param1',
+					name: 'Parameter 1',
+					type: 'Symbol',
+				}]
+			}]
+		};
+
+		const result = await validateActionsManifest(manifest);
+		expect(result).to.deep.equal(manifest.actions);
+	});
+
+	it('throws if a parameter id exceeds 64 characters', async () => {
+		const manifest = {
+			actions: [{
+				type: 'function-invocation',
+				functionId: 'test-function',
+				name: 'Test Action',
+				category: 'Custom',
+				parameters: [{
+					id: 'a'.repeat(65),
+					name: 'Parameter 1',
+					type: 'Symbol',
+				}]
+			}]
+		};
+
+		try {
+			await validateActionsManifest(manifest);
+			expect.fail('expected validateActionsManifest to throw');
+		} catch (error) {
+			expect(error).to.be.instanceOf(Error);
+			expect(error.message).to.include('Invalid App Action manifest');
+			expect(error.message).to.include('invalid "parameters"');
+		}
+	});
+
+	it('throws if a parameter description exceeds 255 characters', async () => {
+		const manifest = {
+			actions: [{
+				type: 'function-invocation',
+				functionId: 'test-function',
+				name: 'Test Action',
+				category: 'Custom',
+				parameters: [{
+					id: 'param1',
+					name: 'Parameter 1',
+					description: 'a'.repeat(256),
+					type: 'Symbol',
+				}]
+			}]
+		};
+
+		try {
+			await validateActionsManifest(manifest);
+			expect.fail('expected validateActionsManifest to throw');
+		} catch (error) {
+			expect(error).to.be.instanceOf(Error);
+			expect(error.message).to.include('invalid "parameters"');
+		}
+	});
+
+	it('throws if a parameter options array is empty', async () => {
+		const manifest = {
+			actions: [{
+				type: 'function-invocation',
+				functionId: 'test-function',
+				name: 'Test Action',
+				category: 'Custom',
+				parameters: [{
+					id: 'param1',
+					name: 'Parameter 1',
+					type: 'Enum',
+					options: [],
+				}]
+			}]
+		};
+
+		try {
+			await validateActionsManifest(manifest);
+			expect.fail('expected validateActionsManifest to throw');
+		} catch (error) {
+			expect(error).to.be.instanceOf(Error);
+			expect(error.message).to.include('invalid "parameters"');
+		}
+	});
+
 	it('throws if a custom category action does not define parameters', async () => {
 		const manifest = {
 			actions: [{

--- a/packages/contentful--app-scripts/src/upsert-actions/validation.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/validation.ts
@@ -1,24 +1,26 @@
-import z from 'zod';
+import {
+	isValidActionId,
+	validateActionParameter,
+	ActionParameterDefinition,
+	MIN_ACTION_ID_LENGTH,
+	MAX_ACTION_ID_LENGTH,
+} from '@contentful/node-apps-toolkit';
 import { CreateAppActionOptions as UpsertAppActionOptions } from './types';
-import { ID_REGEX } from '../utils';
 
-const parametersSchema = z
-	.array(
-		z.object({
-			id: z.string(),
-			name: z.string(),
-			description: z.string().optional(),
-			type: z.enum(['Symbol', 'Enum', 'Number', 'Boolean']),
-			required: z.boolean(),
-			default: z.union([z.string(), z.number(), z.boolean()]).optional(),
-		})
-	)
+const validateParameters = (parameters: unknown[]) => {
+	const errors: string[] = [];
+	parameters.forEach((parameter, index) => {
+		const parameterErrors = validateActionParameter(parameter as ActionParameterDefinition);
+		parameterErrors.forEach((error) => errors.push(`parameters[${index}]: ${error}`));
+	});
+	return errors;
+}
 
 export const validateId = (id: string) => {
-	if (!ID_REGEX.test(id)) {
+	if (!isValidActionId(id)) {
 		return {
 			ok: false,
-			message: `Invalid "id" (must only contain alphanumeric characters). Received: ${id}.`,
+			message: `Invalid "id" (must be ${MIN_ACTION_ID_LENGTH}-${MAX_ACTION_ID_LENGTH} alphanumeric characters). Received: ${id}.`,
 		}
 	}
 	return { ok: true };
@@ -74,9 +76,9 @@ export function validateActionsManifest(
 		}
 
 		if (action.category === 'Custom' && action.parameters) {
-			const parametersValidationResult = parametersSchema.safeParse(action.parameters);
-			if (!parametersValidationResult.success) {
-				acc.push(new Error(`Invalid App Action manifest: invalid "parameters" - ${JSON.stringify(parametersValidationResult.error.errors)}`));
+			const parameterErrors = validateParameters(action.parameters);
+			if (parameterErrors.length) {
+				acc.push(new Error(`Invalid App Action manifest: invalid "parameters" - ${JSON.stringify(parameterErrors)}`));
 			}
 		}
 

--- a/packages/contentful--app-scripts/src/upsert-actions/validation.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/validation.ts
@@ -4,7 +4,8 @@ import {
 	ActionParameterDefinition,
 	MIN_ACTION_ID_LENGTH,
 	MAX_ACTION_ID_LENGTH,
-} from '@contentful/node-apps-toolkit';
+	// eslint-disable-next-line node/no-missing-import
+} from '@contentful/node-apps-toolkit/validation';
 import { CreateAppActionOptions as UpsertAppActionOptions } from './types';
 
 const validateParameters = (parameters: unknown[]) => {

--- a/packages/contentful--app-scripts/src/utils.test.ts
+++ b/packages/contentful--app-scripts/src/utils.test.ts
@@ -61,9 +61,17 @@ describe('isValidIpAddress', () => {
     assert.strictEqual(result, false);
   });
 
-  it('returns false for invalid wildcard domain address', () => {
+  it('returns true for a wildcard domain with multiple subdomain labels', () => {
+    // Regression: the wildcard branch only matched a single subdomain
+    // label, rejecting real customer domains even though the non-wildcard
+    // branch already allows any number of subdomains.
     const result = isValidNetwork('*.too.example.com');
-    assert.strictEqual(result, false);
+    assert.strictEqual(result, true);
+  });
+
+  it('returns true for a wildcard domain with many subdomain labels', () => {
+    const result = isValidNetwork('*.one.two.three.example.com');
+    assert.strictEqual(result, true);
   });
 
   it('returns false for invalid wildcard domain address', () => {

--- a/packages/contentful--app-scripts/src/utils.ts
+++ b/packages/contentful--app-scripts/src/utils.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
+import { isValidNetworkAddress, isValidFunctionEventType } from '@contentful/node-apps-toolkit';
 import { cacheEnvVars } from './cache-credential';
 import { Definition } from './definition-api';
 import { Organization } from './organization-api';
@@ -10,18 +11,6 @@ import { resolve } from 'node:path';
 
 const DEFAULT_MANIFEST_PATH = resolve('.', 'contentful-app-manifest.json');
 
-const functionEvents = {
-  appActionCall: 'appaction.call',
-  appEventFilter: 'appevent.filter',
-  appEventHandler: 'appevent.handler',
-  appEventTransformation: 'appevent.transformation',
-  fieldMappingEvent: 'graphql.field.mapping',
-  resourceTypeMappingEvent: 'graphql.resourcetype.mapping',
-  queryEvent: 'graphql.query',
-  resourceLinksSearchEvent: 'resources.search',
-  resourceLinksLookupEvent: 'resources.lookup',
-};
-
 export const throwValidationException = (subject: string, message?: string, details?: string) => {
   console.log(`${chalk.red('Validation Error:')} Missing or invalid ${subject}.`);
   message && console.log(message);
@@ -30,26 +19,10 @@ export const throwValidationException = (subject: string, message?: string, deta
   throw new TypeError(message);
 };
 
-export const isValidNetwork = (address: string): boolean => {
-  // Regular expression to validate network addresses
-  const addressRegex = new RegExp(
-    '^(?:' + // Start of the non-capturing group for the entire address
-      '(?:' + // Start of the non-capturing group for domain names
-      '(?:\\*\\.)' + // Matches wildcard domains like *.example.com
-      '(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)' + // Matches a single subdomain
-      '[a-zA-Z]{2,63}' + // Matches the top-level domain (TLD). Upper bound of 63 follows RFC 1035 §2.3.4, which defines the maximum length of a single DNS label. ICANN began delegating long gTLDs (e.g. .hosting, .international) from 2012 onwards, making the previous limit of 6 too restrictive.
-      '|' + // OR
-      '(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+' + // Matches standard domains with one or more subdomains
-      '[a-zA-Z]{2,63}' + // Matches the top-level domain (TLD). Upper bound of 63 follows RFC 1035 §2.3.4, which defines the maximum length of a single DNS label. ICANN began delegating long gTLDs (e.g. .hosting, .international) from 2012 onwards, making the previous limit of 6 too restrictive.
-      ')|' + // End of the non-capturing group for domain names, OR
-      '(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}' + // Matches the first three octets of an IPv4 address
-      '(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)|' + // Matches the last octet of an IPv4 address
-      '(\\[(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4}\\]' + // Matches IPv6 addresses in square brackets
-      '|(?:[A-Fa-f0-9]{1,4}:){7}[A-Fa-f0-9]{1,4})' + // Matches IPv6 addresses without square brackets
-      ')(?::\\d{1,5})?$' // Matches an optional port number (1 to 5 digits)
-  );
-  return addressRegex.test(address);
-};
+// Kept as its own export (rather than re-exporting isValidNetworkAddress
+// directly) for backward compatibility with existing consumers of this
+// package's public API.
+export const isValidNetwork = (address: string): boolean => isValidNetworkAddress(address);
 
 export const stripProtocol = (url: string) => {
   const protocolRemovedUrl = url.replace(/^https?:\/\//, '');
@@ -137,9 +110,7 @@ export function getFunctionsFromManifest(): Omit<ContentfulFunction, 'entryFile'
         : [];
 
       const accepts = 'accepts' in item && Array.isArray(item.accepts) ? item.accepts : undefined;
-      const hasInvalidEvent = accepts?.some(
-        (event) => !Object.values(functionEvents).includes(event)
-      );
+      const hasInvalidEvent = accepts?.some((event) => !isValidFunctionEventType(event));
 
       const hasInvalidNetwork = allowNetworks.find((netWork) => !isValidNetwork(netWork));
       if (hasInvalidNetwork) {

--- a/packages/contentful--app-scripts/src/utils.ts
+++ b/packages/contentful--app-scripts/src/utils.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import chalk from 'chalk';
 import inquirer from 'inquirer';
-import { isValidNetworkAddress, isValidFunctionEventType } from '@contentful/node-apps-toolkit';
+// eslint-disable-next-line node/no-missing-import
+import { isValidNetworkAddress, isValidFunctionEventType } from '@contentful/node-apps-toolkit/validation';
 import { cacheEnvVars } from './cache-credential';
 import { Definition } from './definition-api';
 import { Organization } from './organization-api';


### PR DESCRIPTION
## Summary

`app-scripts` implemented its own copies of the rules that decide whether an app manifest is valid — `allowNetworks` entries, App Action and Function ids, hosted code paths, action parameters — and those copies had drifted from the rules the API applies when the manifest is uploaded. The user-visible consequence: a wildcard domain with more than one subdomain label (`*.sub.sub.example.com`) was rejected locally even though it is a perfectly valid address, and some invalid manifests passed here only to fail on upload. This takes all of those rules from `@contentful/node-apps-toolkit`, which now owns them.

## Solution

- `isValidNetwork` now delegates to the shared rule. It keeps its name and signature — it is part of this package's published API — so this is not a breaking change for consumers.
- Replace the local `functionEvents` map with the shared event-topic check.
- Replace the local `parametersSchema` in `upsert-actions` with the shared parameter validator. As a side effect this fixes a real bug: the old zod schema marked `required` as non-optional, so it rejected parameters that `contentful-management` itself treats as valid.
- Derive the id-length error text from the shared bounds rather than hardcoding `1-64`, so the message cannot drift from the rule it describes.
- Close two build-time gaps in `build-functions`: a function `id` was checked for character set but never length, and `path` was not format-checked at all — both previously failed only after upload.
- Correct a test fixture that used `path: 'path/to/file.ts'`; `generate-function` writes `.js`, so the fixture was not a realistic manifest.

## Context

Same-shaped rules living in two codebases is what allowed the wildcard bug: one copy's wildcard branch matched a single subdomain label where the other allowed any number, so the two disagreed about the same address. Consolidating means a fix lands once and both sides pick it up on a version bump.

The shared rules are exported both as pattern strings and as predicates, so this package keeps validating with zod (`.refine(...)`) and does not have to adopt a different validation engine to share the definitions.

**Merge order:** this depends on `@contentful/node-apps-toolkit@^4.1.0`, which is not published yet — contentful/node-apps-toolkit#859 must merge and release first, and CI here will not resolve the dependency until it does. Verified locally against a packed tarball of that branch in the meantime.

## Test plan

- [x] `npm run build` clean against the shared package
- [x] Test suite: 191 passing, up from 181 on `main` (+10 new tests) with no new failures — the 6 pre-existing chalk color-code failures in `build-generate-function-settings.test.ts` are identical on untouched `main` and unrelated to this change
- [x] New tests cover the multi-label wildcard regression, long gTLDs, DNS label bounds, function id length at/over 64, path format, and a parameter with no `required` field
- [x] `npm run lint` — 0 errors
- [x] Confirmed `lib/utils.d.ts` still exports `isValidNetwork`, so the published type surface is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
