### PR TITLE
fix: support parametersSchema in upsert-actions

### DIFF
--- a/packages/contentful--app-scripts/src/upsert-actions/make-cma-payload.test.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/make-cma-payload.test.ts
@@ -45,28 +45,34 @@ describe('makeAppActionCMAPayload', () => {
 
 	it('maps a custom action with parametersSchema and resultSchema', () => {
 		const action: AppActionManifest = {
-			id: 'initiateGdocOauth',
-			name: 'Initiate Gdoc OAuth Flow',
-			description: 'Initiates the OAuth flow for Drive Integration',
+			id: 'customAction',
+			name: 'Custom Action',
+			description: 'A custom function action',
 			type: 'function-invocation',
-			functionId: 'initiateGdocOauth',
+			functionId: 'myFunction',
 			category: 'Custom',
 			parametersSchema: {
 				type: 'object',
+				properties: {
+					input: { type: 'string' },
+				},
 			},
 			resultSchema: {
 				type: 'object',
+				properties: {
+					success: { type: 'boolean' },
+				},
 			},
 		};
 
 		expect(makeAppActionCMAPayload(action)).to.deep.equal({
-			id: 'initiateGdocOauth',
-			name: 'Initiate Gdoc OAuth Flow',
-			description: 'Initiates the OAuth flow for Drive Integration',
+			id: 'customAction',
+			name: 'Custom Action',
+			description: 'A custom function action',
 			type: 'function-invocation',
 			function: {
 				sys: {
-					id: 'initiateGdocOauth',
+					id: 'myFunction',
 					linkType: 'Function',
 					type: 'Link',
 				},
@@ -74,9 +80,15 @@ describe('makeAppActionCMAPayload', () => {
 			category: 'Custom',
 			parametersSchema: {
 				type: 'object',
+				properties: {
+					input: { type: 'string' },
+				},
 			},
 			resultSchema: {
 				type: 'object',
+				properties: {
+					success: { type: 'boolean' },
+				},
 			},
 		});
 	});

--- a/packages/contentful--app-scripts/src/upsert-actions/make-cma-payload.test.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/make-cma-payload.test.ts
@@ -43,6 +43,44 @@ describe('makeAppActionCMAPayload', () => {
 		});
 	});
 
+	it('maps a custom action with parametersSchema and resultSchema', () => {
+		const action: AppActionManifest = {
+			id: 'initiateGdocOauth',
+			name: 'Initiate Gdoc OAuth Flow',
+			description: 'Initiates the OAuth flow for Drive Integration',
+			type: 'function-invocation',
+			functionId: 'initiateGdocOauth',
+			category: 'Custom',
+			parametersSchema: {
+				type: 'object',
+			},
+			resultSchema: {
+				type: 'object',
+			},
+		};
+
+		expect(makeAppActionCMAPayload(action)).to.deep.equal({
+			id: 'initiateGdocOauth',
+			name: 'Initiate Gdoc OAuth Flow',
+			description: 'Initiates the OAuth flow for Drive Integration',
+			type: 'function-invocation',
+			function: {
+				sys: {
+					id: 'initiateGdocOauth',
+					linkType: 'Function',
+					type: 'Link',
+				},
+			},
+			category: 'Custom',
+			parametersSchema: {
+				type: 'object',
+			},
+			resultSchema: {
+				type: 'object',
+			},
+		});
+	});
+
 	it('should allow optional id for function-invocation type action', () => {
 		const action: AppActionManifest = {
 			name: 'Test Function Action',

--- a/packages/contentful--app-scripts/src/upsert-actions/make-cma-payload.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/make-cma-payload.ts
@@ -32,11 +32,13 @@ export function makeAppActionCMAPayload(action: AppActionManifest): CreateAppAct
 				url: action.url,
 			} as EndpointAppActionProps);
 
+	const customAction = action as CustomCategoryAppActionProps;
 	const additionalPropsByCategory =
 		action.category === 'Custom'
 			? ({
 				category: action.category,
-				parameters: (action as CustomCategoryAppActionProps).parameters,
+				...(customAction.parameters !== undefined && { parameters: customAction.parameters }),
+				...(customAction.parametersSchema !== undefined && { parametersSchema: customAction.parametersSchema }),
 			} as CustomCategoryAppActionProps)
 			: ({
 				category: action.category,
@@ -46,6 +48,7 @@ export function makeAppActionCMAPayload(action: AppActionManifest): CreateAppAct
 		...baseProps,
 		...additionalPropsByType,
 		...additionalPropsByCategory,
+		...(action.resultSchema !== undefined && { resultSchema: action.resultSchema }),
 	};
 	return payload;
 }

--- a/packages/contentful--app-scripts/src/upsert-actions/make-cma-payload.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/make-cma-payload.ts
@@ -39,6 +39,7 @@ export function makeAppActionCMAPayload(action: AppActionManifest): CreateAppAct
 				category: action.category,
 				...(customAction.parameters !== undefined && { parameters: customAction.parameters }),
 				...(customAction.parametersSchema !== undefined && { parametersSchema: customAction.parametersSchema }),
+				...(customAction.resultSchema !== undefined && { resultSchema: customAction.resultSchema }),
 			} as CustomCategoryAppActionProps)
 			: ({
 				category: action.category,
@@ -48,7 +49,6 @@ export function makeAppActionCMAPayload(action: AppActionManifest): CreateAppAct
 		...baseProps,
 		...additionalPropsByType,
 		...additionalPropsByCategory,
-		...(action.resultSchema !== undefined && { resultSchema: action.resultSchema }),
 	};
 	return payload;
 }

--- a/packages/contentful--app-scripts/src/upsert-actions/types.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/types.ts
@@ -4,7 +4,6 @@ export type BaseAppActionProps = {
 	id?: string;
 	name: string;
 	description?: string;
-	resultSchema?: Record<string, unknown>;
 }
 export type FunctionAppActionManifestProps = {
 	type: 'function-invocation';
@@ -18,6 +17,7 @@ export type CustomCategoryAppActionProps = {
 	category: 'Custom';
 	parameters?: AppActionParameterDefinition[];
 	parametersSchema?: Record<string, unknown>;
+	resultSchema?: Record<string, unknown>;
 }
 export type BuiltInCategoryAppActionProps = {
 	category: Omit<AppActionCategoryType, 'Custom'>;

--- a/packages/contentful--app-scripts/src/upsert-actions/types.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/types.ts
@@ -4,6 +4,7 @@ export type BaseAppActionProps = {
 	id?: string;
 	name: string;
 	description?: string;
+	resultSchema?: Record<string, unknown>;
 }
 export type FunctionAppActionManifestProps = {
 	type: 'function-invocation';
@@ -15,7 +16,8 @@ export type EndpointAppActionProps = {
 }
 export type CustomCategoryAppActionProps = {
 	category: 'Custom';
-	parameters: AppActionParameterDefinition[];
+	parameters?: AppActionParameterDefinition[];
+	parametersSchema?: Record<string, unknown>;
 }
 export type BuiltInCategoryAppActionProps = {
 	category: Omit<AppActionCategoryType, 'Custom'>;

--- a/packages/contentful--app-scripts/src/upsert-actions/validation.test.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/validation.test.ts
@@ -411,6 +411,46 @@ describe('validateActionsManifest', () => {
 		}
 	});
 
+	it('throws if a native category action defines null parameters', async () => {
+		const manifest = {
+			actions: [{
+				type: 'function-invocation',
+				name: 'Test Action',
+				category: 'Entries.v1.0',
+				functionId: 'test-function',
+				parameters: null,
+			}]
+		};
+
+		try {
+			await validateActionsManifest(manifest);
+			expect.fail('expected validateActionsManifest to throw');
+		} catch (error) {
+			expect(error).to.be.instanceOf(Error);
+			expect(error.message).to.include('may not define "parameters"');
+		}
+	});
+
+	it('throws if a native category action defines null resultSchema', async () => {
+		const manifest = {
+			actions: [{
+				type: 'function-invocation',
+				name: 'Test Action',
+				category: 'Entries.v1.0',
+				functionId: 'test-function',
+				resultSchema: null,
+			}]
+		};
+
+		try {
+			await validateActionsManifest(manifest);
+			expect.fail('expected validateActionsManifest to throw');
+		} catch (error) {
+			expect(error).to.be.instanceOf(Error);
+			expect(error.message).to.include('may not define "resultSchema"');
+		}
+	});
+
 	it('throws if a native category action defines parametersSchema', async () => {
 		const manifest = {
 			actions: [{

--- a/packages/contentful--app-scripts/src/upsert-actions/validation.test.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/validation.test.ts
@@ -255,7 +255,7 @@ describe('validateActionsManifest', () => {
 		}
 	});
 
-	it('throws if a custom category action does not define parameters', async () => {
+	it('throws if a custom category action does not define parameters or parametersSchema', async () => {
 		const manifest = {
 			actions: [{
 				type: 'function-invocation',
@@ -267,9 +267,119 @@ describe('validateActionsManifest', () => {
 
 		try {
 			await validateActionsManifest(manifest);
+			expect.fail('expected validateActionsManifest to throw');
 		} catch (error) {
 			expect(error).to.be.instanceOf(Error);
-			expect(error.message).to.include('Invalid App Action manifest');
+			expect(error.message).to.include('must define "parameters" or "parametersSchema"');
+		}
+	});
+
+	it('validates a custom category action with parametersSchema', async () => {
+		const manifest = {
+			actions: [{
+				type: 'function-invocation',
+				functionId: 'initiateGdocOauth',
+				name: 'Initiate Gdoc OAuth Flow',
+				description: 'Initiates the OAuth flow for Drive Integration',
+				category: 'Custom',
+				parametersSchema: {
+					type: 'object',
+				},
+				resultSchema: {
+					type: 'object',
+				},
+			}]
+		};
+
+		const result = await validateActionsManifest(manifest);
+		expect(result).to.deep.equal(manifest.actions);
+	});
+
+	it('throws if a custom category action defines both parameters and parametersSchema', async () => {
+		const manifest = {
+			actions: [{
+				type: 'function-invocation',
+				functionId: 'test-function',
+				name: 'Test Action',
+				category: 'Custom',
+				parameters: [],
+				parametersSchema: {
+					type: 'object',
+				},
+			}]
+		};
+
+		try {
+			await validateActionsManifest(manifest);
+			expect.fail('expected validateActionsManifest to throw');
+		} catch (error) {
+			expect(error).to.be.instanceOf(Error);
+			expect(error.message).to.include('may not define both "parameters" and "parametersSchema"');
+		}
+	});
+
+	it('throws if parametersSchema is not a JSON Schema object', async () => {
+		const manifest = {
+			actions: [{
+				type: 'function-invocation',
+				functionId: 'test-function',
+				name: 'Test Action',
+				category: 'Custom',
+				parametersSchema: [],
+			}]
+		};
+
+		try {
+			await validateActionsManifest(manifest);
+			expect.fail('expected validateActionsManifest to throw');
+		} catch (error) {
+			expect(error).to.be.instanceOf(Error);
+			expect(error.message).to.include('"parametersSchema" must be a JSON Schema object');
+		}
+	});
+
+	it('throws if resultSchema is not a JSON Schema object', async () => {
+		const manifest = {
+			actions: [{
+				type: 'function-invocation',
+				functionId: 'test-function',
+				name: 'Test Action',
+				category: 'Custom',
+				parametersSchema: {
+					type: 'object',
+				},
+				resultSchema: 'invalid',
+			}]
+		};
+
+		try {
+			await validateActionsManifest(manifest);
+			expect.fail('expected validateActionsManifest to throw');
+		} catch (error) {
+			expect(error).to.be.instanceOf(Error);
+			expect(error.message).to.include('"resultSchema" must be a JSON Schema object');
+		}
+	});
+
+	it('throws if a native category action defines parametersSchema', async () => {
+		const manifest = {
+			actions: [{
+				type: 'function-invocation',
+				name: 'Test Action',
+				category: 'Entries.v1.0',
+				functionId: 'test-function',
+				parametersSchema: {
+					type: 'object',
+				},
+			}]
+		};
+
+		try {
+			await validateActionsManifest(manifest);
+			expect.fail('expected validateActionsManifest to throw');
+		} catch (error) {
+			expect(error).to.be.instanceOf(Error);
+			expect(error.message).to.include('may not define "parametersSchema"');
 		}
 	});
 

--- a/packages/contentful--app-scripts/src/upsert-actions/validation.test.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/validation.test.ts
@@ -278,15 +278,21 @@ describe('validateActionsManifest', () => {
 		const manifest = {
 			actions: [{
 				type: 'function-invocation',
-				functionId: 'initiateGdocOauth',
-				name: 'Initiate Gdoc OAuth Flow',
-				description: 'Initiates the OAuth flow for Drive Integration',
+				functionId: 'myFunction',
+				name: 'Custom Action',
+				description: 'A custom function action',
 				category: 'Custom',
 				parametersSchema: {
 					type: 'object',
+					properties: {
+						input: { type: 'string' },
+					},
 				},
 				resultSchema: {
 					type: 'object',
+					properties: {
+						success: { type: 'boolean' },
+					},
 				},
 			}]
 		};

--- a/packages/contentful--app-scripts/src/upsert-actions/validation.test.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/validation.test.ts
@@ -324,6 +324,50 @@ describe('validateActionsManifest', () => {
 		}
 	});
 
+	it('throws if parameters is null instead of an array', async () => {
+		const manifest = {
+			actions: [{
+				type: 'function-invocation',
+				functionId: 'test-function',
+				name: 'Test Action',
+				category: 'Custom',
+				parameters: null,
+			}]
+		};
+
+		try {
+			await validateActionsManifest(manifest);
+			expect.fail('expected validateActionsManifest to throw');
+		} catch (error) {
+			expect(error).to.be.instanceOf(Error);
+			expect(error.message).to.include('"parameters" must be an array');
+		}
+	});
+
+	it('throws an array error for null parameters even when parametersSchema is present', async () => {
+		const manifest = {
+			actions: [{
+				type: 'function-invocation',
+				functionId: 'test-function',
+				name: 'Test Action',
+				category: 'Custom',
+				parameters: null,
+				parametersSchema: {
+					type: 'object',
+				},
+			}]
+		};
+
+		try {
+			await validateActionsManifest(manifest);
+			expect.fail('expected validateActionsManifest to throw');
+		} catch (error) {
+			expect(error).to.be.instanceOf(Error);
+			expect(error.message).to.include('"parameters" must be an array');
+			expect(error.message).not.to.include('may not define both');
+		}
+	});
+
 	it('throws if parametersSchema is not a JSON Schema object', async () => {
 		const manifest = {
 			actions: [{

--- a/packages/contentful--app-scripts/src/upsert-actions/validation.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/validation.ts
@@ -17,6 +17,10 @@ const validateParameters = (parameters: unknown[]) => {
 	return errors;
 }
 
+const isJsonSchemaObject = (value: unknown): boolean => {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 export const validateId = (id: string) => {
 	if (!isValidActionId(id)) {
 		return {
@@ -72,15 +76,40 @@ export function validateActionsManifest(
 			acc.push(new Error('Invalid App Action manifest: native Action categories may not define "parameters"'));
 		}
 
-		if (action.category === 'Custom' && !action.parameters) {
-			acc.push(new Error('Invalid App Action manifest: "Custom" Action categories must define "parameters"'));
+		if (action.category !== 'Custom' && action.parametersSchema) {
+			acc.push(new Error('Invalid App Action manifest: native Action categories may not define "parametersSchema"'));
 		}
 
-		if (action.category === 'Custom' && action.parameters) {
-			const parameterErrors = validateParameters(action.parameters);
-			if (parameterErrors.length) {
-				acc.push(new Error(`Invalid App Action manifest: invalid "parameters" - ${JSON.stringify(parameterErrors)}`));
+		if (action.category !== 'Custom' && action.resultSchema) {
+			acc.push(new Error('Invalid App Action manifest: native Action categories may not define "resultSchema"'));
+		}
+
+		if (action.category === 'Custom') {
+			const hasParameters = action.parameters !== undefined;
+			const hasParametersSchema = action.parametersSchema !== undefined;
+
+			if (!hasParameters && !hasParametersSchema) {
+				acc.push(new Error('Invalid App Action manifest: "Custom" Action categories must define "parameters" or "parametersSchema"'));
 			}
+
+			if (hasParameters && hasParametersSchema) {
+				acc.push(new Error('Invalid App Action manifest: "Custom" Action categories may not define both "parameters" and "parametersSchema"'));
+			}
+
+			if (hasParameters) {
+				const parameterErrors = validateParameters(action.parameters);
+				if (parameterErrors.length) {
+					acc.push(new Error(`Invalid App Action manifest: invalid "parameters" - ${JSON.stringify(parameterErrors)}`));
+				}
+			}
+
+			if (hasParametersSchema && !isJsonSchemaObject(action.parametersSchema)) {
+				acc.push(new Error('Invalid App Action manifest: "parametersSchema" must be a JSON Schema object'));
+			}
+		}
+
+		if (action.resultSchema !== undefined && !isJsonSchemaObject(action.resultSchema)) {
+			acc.push(new Error('Invalid App Action manifest: "resultSchema" must be a JSON Schema object'));
 		}
 
 		return acc;

--- a/packages/contentful--app-scripts/src/upsert-actions/validation.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/validation.ts
@@ -85,7 +85,11 @@ export function validateActionsManifest(
 		}
 
 		if (action.category === 'Custom') {
-			const hasParameters = action.parameters !== undefined;
+			if (action.parameters !== undefined && !Array.isArray(action.parameters)) {
+				acc.push(new Error('Invalid App Action manifest: "parameters" must be an array'));
+			}
+
+			const hasParameters = Array.isArray(action.parameters);
 			const hasParametersSchema = action.parametersSchema !== undefined;
 
 			if (!hasParameters && !hasParametersSchema) {
@@ -97,7 +101,7 @@ export function validateActionsManifest(
 			}
 
 			if (hasParameters) {
-				const parameterErrors = validateParameters(action.parameters);
+				const parameterErrors = validateParameters(action.parameters as unknown[]);
 				if (parameterErrors.length) {
 					acc.push(new Error(`Invalid App Action manifest: invalid "parameters" - ${JSON.stringify(parameterErrors)}`));
 				}

--- a/packages/contentful--app-scripts/src/upsert-actions/validation.ts
+++ b/packages/contentful--app-scripts/src/upsert-actions/validation.ts
@@ -17,6 +17,8 @@ const validateParameters = (parameters: unknown[]) => {
 	return errors;
 }
 
+const isDefined = (value: unknown): boolean => value !== undefined;
+
 const isJsonSchemaObject = (value: unknown): boolean => {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -72,25 +74,25 @@ export function validateActionsManifest(
 			}
 		}
 
-		if (action.category !== 'Custom' && action.parameters) {
+		if (action.category !== 'Custom' && isDefined(action.parameters)) {
 			acc.push(new Error('Invalid App Action manifest: native Action categories may not define "parameters"'));
 		}
 
-		if (action.category !== 'Custom' && action.parametersSchema) {
+		if (action.category !== 'Custom' && isDefined(action.parametersSchema)) {
 			acc.push(new Error('Invalid App Action manifest: native Action categories may not define "parametersSchema"'));
 		}
 
-		if (action.category !== 'Custom' && action.resultSchema) {
+		if (action.category !== 'Custom' && isDefined(action.resultSchema)) {
 			acc.push(new Error('Invalid App Action manifest: native Action categories may not define "resultSchema"'));
 		}
 
 		if (action.category === 'Custom') {
-			if (action.parameters !== undefined && !Array.isArray(action.parameters)) {
+			if (isDefined(action.parameters) && !Array.isArray(action.parameters)) {
 				acc.push(new Error('Invalid App Action manifest: "parameters" must be an array'));
 			}
 
 			const hasParameters = Array.isArray(action.parameters);
-			const hasParametersSchema = action.parametersSchema !== undefined;
+			const hasParametersSchema = isDefined(action.parametersSchema);
 
 			if (!hasParameters && !hasParametersSchema) {
 				acc.push(new Error('Invalid App Action manifest: "Custom" Action categories must define "parameters" or "parametersSchema"'));
@@ -110,10 +112,10 @@ export function validateActionsManifest(
 			if (hasParametersSchema && !isJsonSchemaObject(action.parametersSchema)) {
 				acc.push(new Error('Invalid App Action manifest: "parametersSchema" must be a JSON Schema object'));
 			}
-		}
 
-		if (action.resultSchema !== undefined && !isJsonSchemaObject(action.resultSchema)) {
-			acc.push(new Error('Invalid App Action manifest: "resultSchema" must be a JSON Schema object'));
+			if (isDefined(action.resultSchema) && !isJsonSchemaObject(action.resultSchema)) {
+				acc.push(new Error('Invalid App Action manifest: "resultSchema" must be a JSON Schema object'));
+			}
 		}
 
 		return acc;


### PR DESCRIPTION
## Summary
- `upsert-actions` now accepts Custom actions that define `parametersSchema` (and optional `resultSchema`) instead of requiring legacy `parameters[]`
- Validation aligns with ext-api: Custom actions need one or the other, not both; native categories may not define schema fields
- `make-cma-payload` forwards `parametersSchema` and `resultSchema` to the CMA create/update payload

Fixes manifests that use JSON Schema fields for Custom app actions (reported by Drive Integration).

## Test plan
- [x] `validation.test.ts` — schema-based Custom actions, mutual-exclusion rules, invalid schema types
- [x] `make-cma-payload.test.ts` — schema fields forwarded to CMA payload
- [x] `npm run build` clean in `contentful--app-scripts`

Generated with [Claude Code](https://claude.com/claude-code) 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>This change enables upsert-actions to process Custom actions that use parametersSchema and optional resultSchema instead of the legacy parameters array. It aligns manifest validation with the schema-based action format and forwards the accepted schema fields into CMA create/update payloads while maintaining compatibility with existing parameter definitions.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Validation now requires Custom actions to define exactly one of parameters or parametersSchema, rejecting manifests that omit both or provide both in validation.ts.</li>

<li>parametersSchema and resultSchema must be non-null JSON Schema objects, and native action categories are rejected when they define either schema field in validation.ts.</li>

<li>CMA payload generation conditionally forwards parametersSchema and resultSchema while continuing to support parameters in make-cma-payload.ts.</li>

<li>Regression coverage in validation.test.ts and make-cma-payload.test.ts exercises valid schema-based actions, invalid schema types, mutual-exclusion rules, native-category restrictions, and payload mapping.</li>

</ul>
</details>

</div>